### PR TITLE
Do not decompose pad op

### DIFF
--- a/coreai_torch/_aten_to_core.py
+++ b/coreai_torch/_aten_to_core.py
@@ -53,6 +53,9 @@ from ._utils import (
 from ._utils import (
     get_operands as _get_operands,
 )
+from ._utils import (
+    replace_pad_with_mode as _replace_pad_with_mode,
+)
 
 INT32_MAX: int = 2147483647
 
@@ -1115,6 +1118,20 @@ def replace_constant_pad_nd(
             coreai.cast(pad_value, x.type.element_type),
         )
     return result
+
+
+def replace_reflection_pad(
+    values_map: dict[str, Value], node: fx.Node, loc: Location
+) -> Value:
+    """aten.reflection_pad{1,2,3}d.default -> coreai.pad<reflect>."""
+    return _replace_pad_with_mode(values_map, node, loc, "reflect")
+
+
+def replace_replication_pad(
+    values_map: dict[str, Value], node: fx.Node, loc: Location
+) -> Value:
+    """aten.replication_pad{1,2,3}d.default -> coreai.pad<replicate>."""
+    return _replace_pad_with_mode(values_map, node, loc, "replicate")
 
 
 def _conv_transpose(
@@ -3559,8 +3576,14 @@ _aten_to_core_resolver: dict[str, Callable[..., Any]] = {
     "prod.default": replace_prod_default,
     "prod.dim_int": replace_prod_dim_int,
     "reciprocal.default": replace_reciprocal,
+    "reflection_pad1d.default": replace_reflection_pad,
+    "reflection_pad2d.default": replace_reflection_pad,
+    "reflection_pad3d.default": replace_reflection_pad,
     "relu.default": replace_unary_ops,
     "remainder.Tensor": replace_remainder,
+    "replication_pad1d.default": replace_replication_pad,
+    "replication_pad2d.default": replace_replication_pad,
+    "replication_pad3d.default": replace_replication_pad,
     "round.default": replace_unary_ops,
     "round.decimals": replace_round_decimals,
     "round": replace_unary_ops,

--- a/coreai_torch/_decomp.py
+++ b/coreai_torch/_decomp.py
@@ -18,6 +18,12 @@ _COMPOSITE_OPS: list = [
     torch.ops.aten.hardswish.default,
     torch.ops.aten.instance_norm.default,
     torch.ops.aten.pixel_shuffle.default,
+    torch.ops.aten.reflection_pad1d.default,
+    torch.ops.aten.reflection_pad2d.default,
+    torch.ops.aten.reflection_pad3d.default,
+    torch.ops.aten.replication_pad1d.default,
+    torch.ops.aten.replication_pad2d.default,
+    torch.ops.aten.replication_pad3d.default,
     torch.ops.aten.scaled_dot_product_attention.default,
     torch.ops.aten.silu.default,
 ]
@@ -40,6 +46,8 @@ def get_decomp_table() -> dict:
     *Direct lowerings:*
 
     * ``torch.ops.aten.hardswish.default``
+    * ``torch.ops.aten.reflection_pad{1,2,3}d.default`` (to ``coreai.pad`` reflect)
+    * ``torch.ops.aten.replication_pad{1,2,3}d.default`` (to ``coreai.pad`` replicate)
     * ``torch.ops.aten.silu.default``
 
     **Usage with** ``add_exported_program`` (caller handles decomposition)::

--- a/coreai_torch/_utils.py
+++ b/coreai_torch/_utils.py
@@ -1034,6 +1034,36 @@ def get_operands(
     return [get_operand(values_map, node, i, loc) for i in indices]
 
 
+def replace_pad_with_mode(
+    values_map: dict[str, Value], node: fx.Node, loc: Location, padding_mode: str
+) -> Value:
+    """aten.reflection_pad{1,2,3}d / replication_pad{1,2,3}d -> coreai.pad.
+
+    These modes only ever produce positive padding (torch has no negative
+    reflect/replicate), so unlike constant_pad_nd there is no cropping path.
+
+    PyTorch pad format: [pad_left_lastdim, pad_right_lastdim, ...]  (reversed)
+    Core AI pad format:  [pad_before_dim0, pad_after_dim0, ...]     (full rank)
+    """
+    x = get_operand(values_map, node, 0)
+    inverted_padding = node.args[1]
+    x_rank = x.type.rank
+
+    padding = [0] * (2 * x_rank)
+    for i in range(0, len(inverted_padding), 2):
+        dim = x_rank - (i // 2) - 1
+        padding[2 * dim] = inverted_padding[i]
+        padding[2 * dim + 1] = inverted_padding[i + 1]
+
+    # padding_value is ignored for non-constant modes, but the op requires one.
+    return coreai.pad(
+        x,
+        np.array(padding, dtype=np.uint32),
+        coreai.cast(0.0, x.type.element_type),
+        padding_mode=padding_mode,
+    )
+
+
 def scalar_constant(py_type: type, value: Any) -> Value:
     """Create a coreai.constant for a scalar kernel arg with the natural dtype.
 

--- a/docs/api/supported-aten-ops.md
+++ b/docs/api/supported-aten-ops.md
@@ -117,9 +117,11 @@ This page lists every PyTorch ATen operator that `TorchConverter` lowers to Core
 | `pow.Scalar`, `pow.Tensor_Scalar`, `pow.Tensor_Tensor` | |
 | `prod.default`, `prod.dim_int` | |
 | `reciprocal.default` | |
+| `reflection_pad1d.default`, `reflection_pad2d.default`, `reflection_pad3d.default` | Lowered to `coreai.pad` with `reflect` mode |
 | `relu.default` | |
 | `remainder.Tensor` | |
 | `repeat.default` | |
+| `replication_pad1d.default`, `replication_pad2d.default`, `replication_pad3d.default` | Lowered to `coreai.pad` with `replicate` mode |
 | `round.default`, `round.decimals` | |
 | `rsqrt.default` | |
 | `scalar_tensor.default` | |

--- a/docs/coreai-core/tutorials/construct-a-graph.ipynb
+++ b/docs/coreai-core/tutorials/construct-a-graph.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "intro",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Constructing a CoreAI Graph\n",
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "warning",
+   "id": "1",
    "metadata": {},
    "source": [
     ":::{warning}\n",
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "setup-md",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -50,25 +50,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:09.232797Z",
-     "iopub.status.busy": "2026-06-04T23:13:09.232330Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.445622Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.444678Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Dev installation detected. Using local Core AI Framework.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import shutil\n",
     "from pathlib import Path\n",
@@ -84,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "specs-md",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Describe the inputs and outputs\n",
@@ -99,26 +84,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "specs",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.447443Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.447294Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.451834Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.451081Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "input:  tensor<2x3xf32>\n",
-      "output: tensor<2x3xf32>\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "input_spec = TensorSpec(shape=[2, 3], dtype=np.float32)\n",
     "output_spec = TensorSpec(shape=[2, 3], dtype=np.float32, name=\"y\")\n",
@@ -129,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "build-md",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Build the graph\n",
@@ -145,25 +114,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "build",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.453228Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.453111Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.470623Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.470201Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Module verified.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "module = Module.create()\n",
     "with module:\n",
@@ -181,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "program-md",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Wrap in an `AIProgram`\n",
@@ -192,16 +146,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "program",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.472009Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.471916Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.474216Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.473635Z"
-    }
-   },
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "program = AIProgram(module)"
@@ -209,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "save-md",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Save as an `.aimodel`\n",
@@ -222,25 +169,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "save",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.475505Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.475388Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.479489Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.479034Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "saved to: hello-graph.aimodel\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "asset_path = Path(\"./hello-graph.aimodel\")\n",
     "if asset_path.exists():\n",
@@ -252,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "inspect-md",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Inspect the saved asset\n",
@@ -263,26 +195,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "inspect",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.480788Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.480705Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.483398Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.483007Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "contents:   ['main.hash', 'main.mlirb', 'metadata.json']\n",
-      "total size: 446 bytes\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "files = sorted(p.name for p in asset_path.iterdir())\n",
     "total_bytes = sum(p.stat().st_size for p in asset_path.rglob(\"*\") if p.is_file())\n",
@@ -293,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "validate-md",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Validate that the asset is loadable\n",
@@ -305,25 +221,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "validate",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.484574Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.484499Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.498350Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.497839Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OK\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "reloaded = AIModelAsset.load(asset_path)\n",
     "async with reloaded.executable() as model:\n",

--- a/docs/coreai-core/tutorials/run-an-aimodel.ipynb
+++ b/docs/coreai-core/tutorials/run-an-aimodel.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "intro",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Running an `.aimodel` with `coreai.runtime`\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "setup-md",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -41,25 +41,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:09.233244Z",
-     "iopub.status.busy": "2026-06-04T23:13:09.232818Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.445952Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.444672Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Dev installation detected. Using local Core AI Framework.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
@@ -72,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ensure-md",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Ensure `hello.aimodel` exists\n",
@@ -84,25 +69,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "ensure",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.447569Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.447413Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.473679Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.473128Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "created hello-run.aimodel\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from shutil import rmtree\n",
     "from typing import Annotated\n",
@@ -132,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "open-asset-md",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Open the asset\n",
@@ -155,16 +125,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "open-asset",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.475086Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.474967Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.477296Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.476906Z"
-    }
-   },
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
    "outputs": [],
    "source": [
     "asset = AIModelAsset.load(asset_path)"
@@ -172,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "run-md",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Open the model and run inference\n",
@@ -195,32 +158,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "run",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.478555Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.478462Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.505717Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.505274Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "functions: ['main']\n",
-      "name:    main\n",
-      "inputs:  ['x']\n",
-      "outputs: ['y']\n",
-      "input x:\n",
-      "[[1.5 1.5 1.5]\n",
-      " [1.5 1.5 1.5]]\n",
-      "output keys: ['y']\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "async with asset.executable() as model:\n",
     "    print(f\"functions: {model.function_names}\")\n",
@@ -245,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "inspect-md",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Inspect the output\n",
@@ -258,30 +199,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "inspect",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-04T23:13:12.506908Z",
-     "iopub.status.busy": "2026-06-04T23:13:12.506825Z",
-     "iopub.status.idle": "2026-06-04T23:13:12.509068Z",
-     "shell.execute_reply": "2026-06-04T23:13:12.508740Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "shape: (2, 3)\n",
-      "dtype: float32\n",
-      "value:\n",
-      "[[3. 3. 3.]\n",
-      " [3. 3. 3.]]\n",
-      "OK — inference produced expected output shape and dtype\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(f\"shape: {result.shape}\")\n",
     "print(f\"dtype: {result.dtype}\")\n",
@@ -294,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "advanced-md",
+   "id": "11",
    "metadata": {},
    "source": [
     "## What's next\n",


### PR DESCRIPTION
* The pad op with modes except `constant` is decomposed into smaller ops, which make the IR complicated.
* Let's exclude the pad op from the default decomposition table and do the lowering ourselves.

Testing:
Unittests