### PR TITLE
atan2: propagate NaN instead of returning 0/pi at x == +/-0

### DIFF
--- a/coreai_torch/_aten_to_core.py
+++ b/coreai_torch/_aten_to_core.py
@@ -1555,6 +1555,9 @@ def replace_atan2(values_map: dict[str, Value], node: fx.Node, loc: Location) ->
       - x == +0: ±π/2 for non-zero y, 0 for y = 0.
       - x == -0: ±π for all y (including ±0 → ±π per IEEE-754).
       - both infinite: ±π/4 or ±3π/4 per IEEE-754.
+      - either operand is NaN: NaN, checked last so it overrides every other
+        branch (comparisons against NaN are all False, which would otherwise
+        misclassify NaN as one of the zero/quadrant cases above).
 
     Signed-zero handling: IEEE-754 treats -0.0 as distinct from +0.0 for atan2
     (e.g. atan2(-0, -1) = -π, not +π). The 1/v trick — 1/-0.0 = -inf — is used
@@ -1603,6 +1606,15 @@ def replace_atan2(values_map: dict[str, Value], node: fx.Node, loc: Location) ->
         coreai.broadcasting_greater(zero, coreai.broadcasting_divide(one, x)),
     )
 
+    # ── NaN branch ─────────────────────────────────────────────────────────────
+    # NaN != NaN under IEEE-754, so this is a self-contained NaN check. Needed
+    # because the x=0 branch below classifies purely on comparisons, which are
+    # all False for NaN and would otherwise misclassify atan2(NaN, ±0).
+    any_nan = coreai.broadcasting_or(
+        coreai.broadcasting_not_equal(y, y), coreai.broadcasting_not_equal(x, x)
+    )
+    nan_result = coreai.constant(float("nan"), dtype=ele_type)
+
     # ── both-infinite branch ──────────────────────────────────────────────────
     # atan(inf/inf) = atan(NaN) = NaN; handle before the divide.
     pos_inf = coreai.constant(float("inf"), dtype=ele_type)
@@ -1649,7 +1661,8 @@ def replace_atan2(values_map: dict[str, Value], node: fx.Node, loc: Location) ->
 
     # ── combine ────────────────────────────────────────────────────────────────
     result = coreai.broadcasting_where(x_is_zero, zero_result, nonzero_result)
-    return coreai.broadcasting_where(both_inf, inf_result, result)
+    result = coreai.broadcasting_where(both_inf, inf_result, result)
+    return coreai.broadcasting_where(any_nan, nan_result, result)
 
 
 def replace_gather(values_map: dict[str, Value], node: fx.Node, loc: Location) -> Value:

--- a/tests/ops/test_ops.py
+++ b/tests/ops/test_ops.py
@@ -681,6 +681,16 @@ class TestAtan2:
         x = torch.tensor([inf, -inf, inf, -inf])
         await validate_numerical_output(model=model, y=y, x=x)
 
+    async def test_nan_propagation(self) -> None:
+        """NaN in either operand must propagate to NaN, including at x = ±0
+        where comparison-based branch selection would otherwise misclassify
+        NaN as one of the zero/quadrant cases."""
+        model = self.Atan2Model().eval()
+        nan = float("nan")
+        y = torch.tensor([nan, nan, 1.0, nan, 0.0])
+        x = torch.tensor([0.0, -0.0, nan, nan, nan])
+        await validate_numerical_output(model=model, y=y, x=x)
+
 
 @pytest.mark.parametrize(
     "x",

--- a/tests/ops/test_ops_ir.py
+++ b/tests/ops/test_ops_ir.py
@@ -1175,6 +1175,7 @@ class TestAtan2IR:
                 // CHECK-NEXT:   coreai.graph @main(%[[Y:.*]]: tensor<2x3xf32> {coreai.name = "y"}, %[[X:.*]]: tensor<2x3xf32> {coreai.name = "x"}) -> (tensor<2x3xf32> {coreai.name = "{{.*}}"}) attributes {__coreai_pure__} {
                 // CHECK:          %[[NEG_INF:.*]] = coreai.constant dense<0xFF800000> : tensor<f32>
                 // CHECK:          %[[POS_INF:.*]] = coreai.constant dense<0x7F800000> : tensor<f32>
+                // CHECK:          %[[NAN:.*]] = coreai.constant dense<0x7FC00000> : tensor<f32>
                 // CHECK:          %[[ZERO:.*]] = coreai.constant dense<0.000000e+00> : tensor<f32>
                 // CHECK:          %[[ONE:.*]] = coreai.constant dense<1.000000e+00> : tensor<f32>
                 // CHECK:          %[[PI:.*]] = coreai.constant dense<3.14159274> : tensor<f32>
@@ -1197,6 +1198,9 @@ class TestAtan2IR:
                 // CHECK:          %[[RECIP_X_NEG:.*]] = coreai.decomposable.broadcasting_greater %[[ZERO]], %[[RECIP_X]]
                 // CHECK:          %[[X_ZERO_NEG:.*]] = coreai.decomposable.broadcasting_and %[[X_IS_ZERO]], %[[RECIP_X_NEG]]
                 // CHECK:          %[[X_NEG:.*]] = coreai.decomposable.broadcasting_or %[[X_NEG_STRICT]], %[[X_ZERO_NEG]]
+                // CHECK:          %[[Y_NOT_EQ_Y:.*]] = coreai.decomposable.broadcasting_not_equal %[[Y]], %[[Y]]
+                // CHECK:          %[[X_NOT_EQ_X:.*]] = coreai.decomposable.broadcasting_not_equal %[[X]], %[[X]]
+                // CHECK:          %[[ANY_NAN:.*]] = coreai.decomposable.broadcasting_or %[[Y_NOT_EQ_Y]], %[[X_NOT_EQ_X]]
                 // CHECK:          %[[X_IS_POS_INF:.*]] = coreai.decomposable.broadcasting_equal %[[X]], %[[POS_INF]]
                 // CHECK:          %[[X_IS_NEG_INF:.*]] = coreai.decomposable.broadcasting_equal %[[X]], %[[NEG_INF]]
                 // CHECK:          %[[X_IS_INF:.*]] = coreai.decomposable.broadcasting_or %[[X_IS_POS_INF]], %[[X_IS_NEG_INF]]
@@ -1205,7 +1209,8 @@ class TestAtan2IR:
                 // CHECK:          %[[Y_IS_INF:.*]] = coreai.decomposable.broadcasting_or %[[Y_IS_POS_INF]], %[[Y_IS_NEG_INF]]
                 // CHECK:          %[[BOTH_INF:.*]] = coreai.decomposable.broadcasting_and %[[X_IS_INF]], %[[Y_IS_INF]]
                 // CHECK:          %[[BASE:.*]] = coreai.atan
-                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[INF_RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[ANY_NAN]], %[[NAN]], %[[INF_RESULT]]
                 // CHECK-NEXT:     coreai.output %[[RESULT]] : tensor<2x3xf32>
                 // CHECK-NEXT:   }
                 // CHECK-NEXT: }
@@ -1232,6 +1237,7 @@ class TestAtan2IR:
                 // CHECK-NEXT:   coreai.graph @main(%[[Y:.*]]: tensor<?x?xf32> {coreai.name = "y"}, %[[X:.*]]: tensor<?x?xf32> {coreai.name = "x"}) -> (tensor<?x?xf32> {coreai.name = "{{.*}}"}) attributes {__coreai_pure__} {
                 // CHECK:          %[[NEG_INF:.*]] = coreai.constant dense<0xFF800000> : tensor<f32>
                 // CHECK:          %[[POS_INF:.*]] = coreai.constant dense<0x7F800000> : tensor<f32>
+                // CHECK:          %[[NAN:.*]] = coreai.constant dense<0x7FC00000> : tensor<f32>
                 // CHECK:          %[[ZERO:.*]] = coreai.constant dense<0.000000e+00> : tensor<f32>
                 // CHECK:          %[[ONE:.*]] = coreai.constant dense<1.000000e+00> : tensor<f32>
                 // CHECK:          %[[PI:.*]] = coreai.constant dense<3.14159274> : tensor<f32>
@@ -1254,6 +1260,9 @@ class TestAtan2IR:
                 // CHECK:          %[[RECIP_X_NEG:.*]] = coreai.decomposable.broadcasting_greater %[[ZERO]], %[[RECIP_X]]
                 // CHECK:          %[[X_ZERO_NEG:.*]] = coreai.decomposable.broadcasting_and %[[X_IS_ZERO]], %[[RECIP_X_NEG]]
                 // CHECK:          %[[X_NEG:.*]] = coreai.decomposable.broadcasting_or %[[X_NEG_STRICT]], %[[X_ZERO_NEG]]
+                // CHECK:          %[[Y_NOT_EQ_Y:.*]] = coreai.decomposable.broadcasting_not_equal %[[Y]], %[[Y]]
+                // CHECK:          %[[X_NOT_EQ_X:.*]] = coreai.decomposable.broadcasting_not_equal %[[X]], %[[X]]
+                // CHECK:          %[[ANY_NAN:.*]] = coreai.decomposable.broadcasting_or %[[Y_NOT_EQ_Y]], %[[X_NOT_EQ_X]]
                 // CHECK:          %[[X_IS_POS_INF:.*]] = coreai.decomposable.broadcasting_equal %[[X]], %[[POS_INF]]
                 // CHECK:          %[[X_IS_NEG_INF:.*]] = coreai.decomposable.broadcasting_equal %[[X]], %[[NEG_INF]]
                 // CHECK:          %[[X_IS_INF:.*]] = coreai.decomposable.broadcasting_or %[[X_IS_POS_INF]], %[[X_IS_NEG_INF]]
@@ -1262,7 +1271,8 @@ class TestAtan2IR:
                 // CHECK:          %[[Y_IS_INF:.*]] = coreai.decomposable.broadcasting_or %[[Y_IS_POS_INF]], %[[Y_IS_NEG_INF]]
                 // CHECK:          %[[BOTH_INF:.*]] = coreai.decomposable.broadcasting_and %[[X_IS_INF]], %[[Y_IS_INF]]
                 // CHECK:          %[[BASE:.*]] = coreai.atan
-                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[INF_RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[ANY_NAN]], %[[NAN]], %[[INF_RESULT]]
                 // CHECK-NEXT:     coreai.output %[[RESULT]] : tensor<?x?xf32>
                 // CHECK-NEXT:   }
                 // CHECK-NEXT: }
@@ -1284,9 +1294,11 @@ class TestAtan2IR:
                 // CHECK:          %[[ONE:.*]] = coreai.constant dense<1.000000e+00> : tensor<f32>
                 // CHECK:          %[[Y_NEG:.*]] = coreai.decomposable.broadcasting_or
                 // CHECK:          %[[X_NEG:.*]] = coreai.decomposable.broadcasting_or
+                // CHECK:          %[[ANY_NAN:.*]] = coreai.decomposable.broadcasting_or
                 // CHECK:          %[[BOTH_INF:.*]] = coreai.decomposable.broadcasting_and
                 // CHECK:          %[[BASE:.*]] = coreai.atan
-                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[INF_RESULT:.*]] = coreai.decomposable.broadcasting_where %[[BOTH_INF]],
+                // CHECK:          %[[RESULT:.*]] = coreai.decomposable.broadcasting_where %[[ANY_NAN]],
                 // CHECK-NEXT:     coreai.output %[[RESULT]] : tensor<4xf32>
                 // CHECK-NEXT:   }
                 // CHECK-NEXT: }


### PR DESCRIPTION
## Description

The `atan2` converter's x=0 branch classifies inputs purely via comparisons (`y > 0`, `0 > y`, etc.), which are all `False` when NaN is involved. This meant `atan2(NaN, +0.0)` incorrectly returned `0` and `atan2(NaN, -0.0)` incorrectly returned `pi`, instead of `NaN` as required by IEEE-754 and matched by `torch.atan2`.

This adds an explicit NaN check (`y != y or x != x`) that takes priority over every other branch in the decomposition, so NaN now always propagates through correctly.

## Testing

- Added `test_nan_propagation` to `TestAtan2` in `tests/ops/test_ops.py`, covering NaN in `y`, `x`, and both, including at `x = +/-0`.
- Updated the three `TestAtan2IR` FileCheck patterns in `tests/ops/test_ops_ir.py` to match the new IR shape (extra NaN constant + final NaN-select `where`).
- Full `tests/ops/` suite passes locally.
