### PR TITLE
int-reduce-int64-narrowing-overflow: fix sum/prod int64 accumulator narrowing

### DIFF
--- a/coreai_torch/_aten_to_core.py
+++ b/coreai_torch/_aten_to_core.py
@@ -2682,8 +2682,7 @@ def replace_sum_dim_intlist(
     reducing: torch promotes narrower integer sums to int64 specifically so
     the accumulation doesn't overflow, and reduce_sum's own IR contract is
     same-dtype-in/same-dtype-out (no internal promotion) -- narrowing the
-    accumulator here would make the reduction itself overflow early. See
-    BUG-012.
+    accumulator here would make the reduction itself overflow early.
     """
     x = _get_operand(values_map, node, 0)
     args = node.args
@@ -2746,7 +2745,7 @@ def replace_prod_default(
     """Converts aten.prod.default to coreai.reduce_product.
 
     See replace_sum_dim_intlist for why the accumulator target type must not
-    be narrowed here (BUG-012).
+    be narrowed here.
     """
     x = _get_operand(values_map, node, 0)
     target_type = get_unnarrowed_output_element_type_from_node(node)
@@ -2762,7 +2761,7 @@ def replace_prod_dim_int(
     """Converts aten.prod.dim_int to coreai.reduce_product.
 
     See replace_sum_dim_intlist for why the accumulator target type must not
-    be narrowed here (BUG-012).
+    be narrowed here.
     """
     x = _get_operand(values_map, node, 0)
     target_type = get_unnarrowed_output_element_type_from_node(node)

--- a/coreai_torch/_aten_to_core.py
+++ b/coreai_torch/_aten_to_core.py
@@ -2676,14 +2676,7 @@ def replace_squeeze_dims(
 def replace_sum_dim_intlist(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
-    """Converts aten.sum.dim_IntList to coreai.reduce_sum.
-
-    Casts to the *unnarrowed* promoted type (e.g. int64, not int32) before
-    reducing: torch promotes narrower integer sums to int64 specifically so
-    the accumulation doesn't overflow, and reduce_sum's own IR contract is
-    same-dtype-in/same-dtype-out (no internal promotion) -- narrowing the
-    accumulator here would make the reduction itself overflow early.
-    """
+    """Converts aten.sum.dim_IntList to coreai.reduce_sum."""
     x = _get_operand(values_map, node, 0)
     args = node.args
 
@@ -2742,11 +2735,6 @@ def replace_topk(
 def replace_prod_default(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
-    """Converts aten.prod.default to coreai.reduce_product.
-
-    See replace_sum_dim_intlist for why the accumulator target type must not
-    be narrowed here.
-    """
     x = _get_operand(values_map, node, 0)
     target_type = get_unnarrowed_output_element_type_from_node(node)
     if x.type.element_type != target_type:
@@ -2758,11 +2746,6 @@ def replace_prod_default(
 def replace_prod_dim_int(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
-    """Converts aten.prod.dim_int to coreai.reduce_product.
-
-    See replace_sum_dim_intlist for why the accumulator target type must not
-    be narrowed here.
-    """
     x = _get_operand(values_map, node, 0)
     target_type = get_unnarrowed_output_element_type_from_node(node)
     if x.type.element_type != target_type:

--- a/coreai_torch/_aten_to_core.py
+++ b/coreai_torch/_aten_to_core.py
@@ -37,6 +37,7 @@ from ._utils import (
     get_target,
     get_tensor_shape_at_index,
     get_tensor_type,
+    get_unnarrowed_output_element_type_from_node,
     prepare_compute_type_for_norm,
     process_expanded_indices,
     process_indices_with_transpose,
@@ -2675,11 +2676,19 @@ def replace_squeeze_dims(
 def replace_sum_dim_intlist(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
-    """Converts aten.sum.dim_IntList to coreai.reduce_sum."""
+    """Converts aten.sum.dim_IntList to coreai.reduce_sum.
+
+    Casts to the *unnarrowed* promoted type (e.g. int64, not int32) before
+    reducing: torch promotes narrower integer sums to int64 specifically so
+    the accumulation doesn't overflow, and reduce_sum's own IR contract is
+    same-dtype-in/same-dtype-out (no internal promotion) -- narrowing the
+    accumulator here would make the reduction itself overflow early. See
+    BUG-012.
+    """
     x = _get_operand(values_map, node, 0)
     args = node.args
 
-    target_type = get_output_element_type_from_node(node)
+    target_type = get_unnarrowed_output_element_type_from_node(node)
     if x.type.element_type != target_type:
         x = coreai.cast(x, target_type)
 
@@ -2734,8 +2743,13 @@ def replace_topk(
 def replace_prod_default(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
+    """Converts aten.prod.default to coreai.reduce_product.
+
+    See replace_sum_dim_intlist for why the accumulator target type must not
+    be narrowed here (BUG-012).
+    """
     x = _get_operand(values_map, node, 0)
-    target_type = get_output_element_type_from_node(node)
+    target_type = get_unnarrowed_output_element_type_from_node(node)
     if x.type.element_type != target_type:
         x = coreai.cast(x, target_type)
     all_dims = list(range(x.type.rank))
@@ -2745,8 +2759,13 @@ def replace_prod_default(
 def replace_prod_dim_int(
     values_map: dict[str, Value], node: fx.Node, loc: Location
 ) -> Value:
+    """Converts aten.prod.dim_int to coreai.reduce_product.
+
+    See replace_sum_dim_intlist for why the accumulator target type must not
+    be narrowed here (BUG-012).
+    """
     x = _get_operand(values_map, node, 0)
-    target_type = get_output_element_type_from_node(node)
+    target_type = get_unnarrowed_output_element_type_from_node(node)
     if x.type.element_type != target_type:
         x = coreai.cast(x, target_type)
     dim: int = node.args[1]

--- a/coreai_torch/_utils.py
+++ b/coreai_torch/_utils.py
@@ -486,7 +486,7 @@ def get_unnarrowed_output_element_type_from_node(
     unlike narrowing a plain value cast, which is lossless-by-convention for
     values already known to fit (or that the model owner accepts truncating).
     coreai's own IR supports int64 (``si64``) as a first-class type, so
-    producing it here is not a runtime limitation -- see BUG-012.
+    producing it here is not a runtime limitation.
     """
     val = node.meta["val"]
     if index is not None:

--- a/coreai_torch/_utils.py
+++ b/coreai_torch/_utils.py
@@ -473,6 +473,39 @@ def get_output_element_type_from_node(node: fx.Node, index: int | None = None) -
     return TORCH_TO_COREAI_DTYPE[dtype]()
 
 
+def get_unnarrowed_output_element_type_from_node(
+    node: fx.Node, index: int | None = None
+) -> Type:
+    """Return the element type for a node's output, without int64/float64 narrowing.
+
+    Like :func:`get_output_element_type_from_node`, but skips the
+    ``_NARROW_TORCH_DTYPE`` step. Intended for accumulator-style ops (e.g.
+    ``sum``/``prod`` reductions) whose torch semantics require accumulating at
+    the full promoted width (int64) to avoid overflowing early -- narrowing
+    the accumulator *before* the op runs silently changes its numeric result,
+    unlike narrowing a plain value cast, which is lossless-by-convention for
+    values already known to fit (or that the model owner accepts truncating).
+    coreai's own IR supports int64 (``si64``) as a first-class type, so
+    producing it here is not a runtime limitation -- see BUG-012.
+    """
+    val = node.meta["val"]
+    if index is not None:
+        val = val[index]
+
+    if isinstance(val, torch.Tensor):
+        dtype = val.dtype
+    elif isinstance(val, (float, torch.SymFloat)):
+        dtype = torch.float32
+    elif isinstance(val, (int, torch.SymInt)):
+        dtype = torch.int32
+    elif isinstance(val, (bool, torch.SymBool)):
+        dtype = torch.bool
+    else:
+        dtype = val.dtype  # fall back to original behaviour
+
+    return TORCH_TO_COREAI_DTYPE[dtype]()
+
+
 @dataclass
 class _StackedIndexInfo:
     """Stacked indices and permutations for gather_nd/scatter_nd.

--- a/tests/ops/test_ops.py
+++ b/tests/ops/test_ops.py
@@ -6427,8 +6427,8 @@ async def test_prod_default(x: Tensor, dynamic: bool) -> None:
     ],
 )
 async def test_sum_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
-    """Regression test for BUG-012: sum's int64 accumulator must not be
-    narrowed to int32, which would make the reduction silently wrap."""
+    """sum's int64 accumulator must not be narrowed to int32, which would
+    make the reduction silently wrap."""
 
     class SumModel(nn.Module):
         def forward(self, x: Tensor) -> Tensor:
@@ -6456,7 +6456,7 @@ async def test_sum_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
 async def test_sum_dim_intlist_int_promotes_to_int64_no_overflow(
     x: Tensor, dims: list[int], keepdim: bool
 ) -> None:
-    """Regression test for BUG-012, explicit dim_IntList + keepdim variant."""
+    """Explicit dim_IntList + keepdim variant of the int64-promoted sum."""
 
     class SumModel(nn.Module):
         def forward(self, x: Tensor) -> Tensor:
@@ -6480,8 +6480,8 @@ async def test_sum_dim_intlist_int_promotes_to_int64_no_overflow(
     ],
 )
 async def test_prod_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
-    """Regression test for BUG-012: prod's int64 accumulator must not be
-    narrowed to int32, which would make the reduction silently wrap."""
+    """prod's int64 accumulator must not be narrowed to int32, which would
+    make the reduction silently wrap."""
 
     class ProdModel(nn.Module):
         def forward(self, x: Tensor) -> Tensor:
@@ -6502,7 +6502,7 @@ async def test_prod_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
     ],
 )
 async def test_prod_dim_int_promotes_to_int64_no_overflow(x: Tensor, dim: int) -> None:
-    """Regression test for BUG-012, dim_int variant of prod."""
+    """dim_int variant of the int64-promoted prod."""
 
     class ProdModel(nn.Module):
         def forward(self, x: Tensor) -> Tensor:

--- a/tests/ops/test_ops.py
+++ b/tests/ops/test_ops.py
@@ -6443,11 +6443,40 @@ async def test_sum_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
 
 
 @pytest.mark.parametrize(
+    "x,dims,keepdim",
+    [
+        # Explicit dim list + keepdim, exercising the branch of
+        # replace_sum_dim_intlist that doesn't reduce all dims via the
+        # empty-list path (see test_sum_int_promotes_to_int64_no_overflow
+        # above, which only covers torch.sum(x) with no dim/keepdim args).
+        (torch.full((2, 3), 2147483647, dtype=torch.int32), [0, 1], True),
+        (torch.full((2, 3), 2147483647, dtype=torch.int32), [0, 1], False),
+    ],
+)
+async def test_sum_dim_intlist_int_promotes_to_int64_no_overflow(
+    x: Tensor, dims: list[int], keepdim: bool
+) -> None:
+    """Regression test for BUG-012, explicit dim_IntList + keepdim variant."""
+
+    class SumModel(nn.Module):
+        def forward(self, x: Tensor) -> Tensor:
+            return torch.sum(x, dim=dims, keepdim=keepdim)
+
+    model = SumModel().eval()
+    torch_out = model(x)
+    assert torch_out.dtype == torch.int64
+
+    await validate_numerical_output(model=model, x=x)
+
+
+@pytest.mark.parametrize(
     "x",
     [
         # torch.prod(int32) promotes to int64: 70000 * 70000 = 4900000000,
         # which fits in int64 but overflows int32.
         torch.tensor([70000, 70000], dtype=torch.int32),
+        # Negative-value overflow: promotion to int64 is sign-agnostic.
+        torch.tensor([-70000, 70000], dtype=torch.int32),
     ],
 )
 async def test_prod_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
@@ -6461,7 +6490,7 @@ async def test_prod_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
     model = ProdModel().eval()
     torch_out = model(x)
     assert torch_out.dtype == torch.int64
-    assert torch_out.item() == 70000 * 70000
+    assert torch_out.item() == x[0].item() * x[1].item()
 
     await validate_numerical_output(model=model, x=x)
 

--- a/tests/ops/test_ops.py
+++ b/tests/ops/test_ops.py
@@ -6417,6 +6417,75 @@ async def test_prod_default(x: Tensor, dynamic: bool) -> None:
     await validate_numerical_output(model=model, x=x, dynamic_shapes=dynamic_shapes)
 
 
+@pytest.mark.parametrize(
+    "x",
+    [
+        # torch.sum(int32) promotes to int64: two INT32_MAX values sum to
+        # 4294967294, which fits in int64 but overflows (wraps) int32.
+        torch.tensor([2147483647, 2147483647], dtype=torch.int32),
+        torch.full((3, 4), 2147483647, dtype=torch.int32),
+    ],
+)
+async def test_sum_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
+    """Regression test for BUG-012: sum's int64 accumulator must not be
+    narrowed to int32, which would make the reduction silently wrap."""
+
+    class SumModel(nn.Module):
+        def forward(self, x: Tensor) -> Tensor:
+            return torch.sum(x)
+
+    model = SumModel().eval()
+    torch_out = model(x)
+    assert torch_out.dtype == torch.int64
+    assert torch_out.item() == x.numel() * 2147483647
+
+    await validate_numerical_output(model=model, x=x)
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        # torch.prod(int32) promotes to int64: 70000 * 70000 = 4900000000,
+        # which fits in int64 but overflows int32.
+        torch.tensor([70000, 70000], dtype=torch.int32),
+    ],
+)
+async def test_prod_int_promotes_to_int64_no_overflow(x: Tensor) -> None:
+    """Regression test for BUG-012: prod's int64 accumulator must not be
+    narrowed to int32, which would make the reduction silently wrap."""
+
+    class ProdModel(nn.Module):
+        def forward(self, x: Tensor) -> Tensor:
+            return torch.prod(x)
+
+    model = ProdModel().eval()
+    torch_out = model(x)
+    assert torch_out.dtype == torch.int64
+    assert torch_out.item() == 70000 * 70000
+
+    await validate_numerical_output(model=model, x=x)
+
+
+@pytest.mark.parametrize(
+    "x,dim",
+    [
+        (torch.tensor([[2147483647, 2147483647]], dtype=torch.int32), 1),
+    ],
+)
+async def test_prod_dim_int_promotes_to_int64_no_overflow(x: Tensor, dim: int) -> None:
+    """Regression test for BUG-012, dim_int variant of prod."""
+
+    class ProdModel(nn.Module):
+        def forward(self, x: Tensor) -> Tensor:
+            return torch.prod(x, dim=dim)
+
+    model = ProdModel().eval()
+    torch_out = model(x)
+    assert torch_out.dtype == torch.int64
+
+    await validate_numerical_output(model=model, x=x)
+
+
 @pytest.mark.parametrize("dynamic", [False, True])
 @pytest.mark.parametrize(
     "x,dims",


### PR DESCRIPTION
## Summary

`torch.sum`/`torch.prod` on a narrower integer input (e.g. `int32`) promote
the accumulator to `int64` per PyTorch's own type-promotion contract,
specifically so accumulation doesn't overflow (confirmed:
`torch.sum(torch.tensor([2**31-1, 2**31-1], dtype=torch.int32))` returns
`4294967294`, `dtype=torch.int64`, no overflow).

`replace_sum_dim_intlist`/`replace_prod_default`/`replace_prod_dim_int`
(`coreai_torch/_aten_to_core.py`) cast the input to a "target type" before
calling `coreai.reduce_sum`/`coreai.reduce_product` — but that target type
came from `get_output_element_type_from_node` (`coreai_torch/_utils.py`),
which unconditionally narrows `int64` to `int32` via `_NARROW_TORCH_DTYPE`.
That made the reduction itself run (and overflow) in `int32` instead of
`int64`, silently wrapping identically on every backend (interpreter, cpu,
gpu, ane) — this corrupts the lowered IR itself, upstream of any backend.

## Root cause

`_NARROW_TORCH_DTYPE`'s int64-to-int32 narrowing (`_utils.py`) is correct
for most call sites (plain value casts where the model owner accepts
truncation), but wrong for an accumulator that PyTorch specifically widens
to avoid overflowing *during* the operation — narrowing it before the
reduction runs changes the reduction's numeric result, not just its output
representation.

## Fix

Added `get_unnarrowed_output_element_type_from_node` (`coreai_torch/_utils.py`),
identical to `get_output_element_type_from_node` but without the
`_NARROW_TORCH_DTYPE` step, and switched the three sum/prod reduction
lowerings to use it. `_NARROW_TORCH_DTYPE` and
`get_output_element_type_from_node` itself are unchanged — they're relied on
by ~15 other lowering call sites (elementwise casts, `cumsum`, `where`,
`nonzero`, etc.) where narrowing is intentional and out of scope here.
CoreAI's IR already supports `int64` (`si64`) as a first-class type, so this
isn't a runtime limitation — just a lowering policy fix.

**Known related gap, intentionally not fixed here:** `replace_cumsum` has
the same accumulator-narrowing shape (`torch.cumsum` also promotes to
`int64`) and is not touched by this PR — keeping this fix scoped to
`sum`/`prod` as originally triaged. Flagging it here so it isn't lost:
`cumsum`'s narrowing appears to additionally crash rather than silently
wrap when pressed with an overflowing input, so it likely needs separate,
dedicated attention.

## Test plan

- [x] Added regression tests in `tests/ops/test_ops.py` covering
      `torch.sum`/`torch.prod` (default, explicit `dim_IntList` + `keepdim`,
      and `dim_int` variants) on `int32` inputs that overflow `int32` but not
      `int64` when reduced, asserting `dtype == torch.int64` and full
      numerical correctness via `validate_numerical_output`.
- [x] `ruff check`/`ruff format`/`pre-commit run` clean.
- [x] Full suite: `uv run pytest tests/ -n auto -q -p no:rerunfailures -p no:randomly`
      passes except pre-existing flaky failures in
      `tests/composite_ops/test_gated_delta_update.py`
      (`@pytest.mark.flaky(reruns=3)`), confirmed pre-existing/flaky by
      reproducing a failure in that same file on a clean `origin/main`
      checkout.
- [x] Confirms the previously-filed regression repro (internal tracking;
      see linked test dir) now passes on all four backends
      (interpreter/cpu/gpu/ane) instead of silently wrapping.

Regression test dir (internal tracking, not part of this repo):
`wiki/work/experiments/coreai/tests/regression/010-int-reduce-int64-narrowing-overflow/`
