### PR TITLE
Fix sidebar clipping of long dotted identifiers

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -99,6 +99,18 @@ html.dark code.docutils {
     font-weight: 600;
 }
 
+/* Allow long dotted FQNs to wrap in the sidebar instead of clipping */
+.sy-sidebar-toc,
+.sy-sidebar-toc ul,
+.sy-sidebar-toc li {
+    overflow: visible;
+}
+
+.sy-lside a {
+    white-space: normal;
+    word-break: break-word;
+}
+
 /* Reset code font in sidebar nav — prevents identifier-titled pages
  * (e.g. generate_composite_decl) from rendering in monospace */
 .sy-lside a code {

--- a/docs/_static/sidebar-wrap.js
+++ b/docs/_static/sidebar-wrap.js
@@ -1,0 +1,21 @@
+// Copyright 2026 Apple Inc.
+//
+// Use of this source code is governed by a BSD-3-Clause license that can
+// be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+
+// Break sidebar entries at `.` boundaries so long dotted FQNs wrap cleanly
+// (e.g. `coreai_opt.quantization.QuantizerConfig.presets.w4` wraps between
+// segments rather than mid-word). Inserts a zero-width space (U+200B) after
+// each `.`, which the browser treats as a valid line-break opportunity when
+// combined with `white-space: normal` in the sidebar CSS.
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll(".wy-menu-vertical li a").forEach(function (link) {
+    // Only touch the text nodes — don't mangle any HTML inside (e.g. icons).
+    link.childNodes.forEach(function (node) {
+      if (node.nodeType === Node.TEXT_NODE && node.textContent.indexOf(".") !== -1) {
+        node.textContent = node.textContent.replace(/\./g, ".​");
+      }
+    });
+  });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ nb_remove_code_outputs = True
 html_theme = "shibuya"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
-html_js_files = ["copy-page-button.js"]
+html_js_files = ["sidebar-wrap.js", "copy-page-button.js"]
 templates_path = ["_templates"]
 html_show_sourcelink = False
 


### PR DESCRIPTION
Adds sidebar-wrap.js (injects zero-width spaces after dots in FQNs so they wrap at segment boundaries) and CSS overrides to allow overflow and enable word-break in sidebar links.