### PR TITLE
[clean up] Remove run_transforms helper in favor of AIProgram.optimize()

### DIFF
--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -26,7 +26,6 @@ from coreai_torch import TorchConverter, get_decomp_table
 from .utils import (
     filecheck_pattern,
     make_dynamic_shapes,
-    run_transforms,
     validate_numerical_output,
 )
 
@@ -229,7 +228,7 @@ class TestMutableBufferAnnotation:
             .add_exported_program(self._mutable_buffer_program())
             .to_coreai()
         )
-        await run_transforms(result)
+        result.optimize()
         filecheck_pattern(
             str(result),
             check_file="""
@@ -395,7 +394,7 @@ class TestMutableUserInputAnnotation:
         result = (
             TorchConverter().add_exported_program(self._mutating_program()).to_coreai()
         )
-        await run_transforms(result)
+        result.optimize()
         filecheck_pattern(
             str(result),
             check_file="""
@@ -507,7 +506,7 @@ class TestMutableBufferAndUserInputAnnotation:
             .add_exported_program(self._both_mutations_program())
             .to_coreai()
         )
-        await run_transforms(result)
+        result.optimize()
         filecheck_pattern(
             str(result),
             check_file="""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,9 +16,6 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import torch
-from coreai._compiler._transforms import GlobalOptions, PassEntry, apply_passes
-from coreai._compiler._transforms.passes import CorePasses
-from coreai.authoring import AIProgram
 from coreai.runtime import NDArray, StorageKind
 from filecheck.matcher import Matcher
 from filecheck.options import Options
@@ -79,19 +76,6 @@ def _get_test_specialization_options() -> "SpecializationOptions | None":
         )
     msg = f"Unknown compute unit kind: {_COMPUTE_UNIT_KIND!r}"
     raise ValueError(msg)
-
-
-async def run_transforms(coreai_program: AIProgram) -> None:
-    """Run essential transformation passes."""
-    await apply_passes(
-        coreai_program._mlir_module,
-        passes=[
-            PassEntry.get(CorePasses._CORE_OPTIMIZE),
-            PassEntry.get(CorePasses._UPDATE_SIGNATURE_TO_HANDLES),
-            PassEntry.get(CorePasses._PROPAGATE_HANDLE_UPDATES),
-        ],
-        options=GlobalOptions(Path()),
-    )
 
 
 def make_dynamic_shapes(


### PR DESCRIPTION
Removes the run_transforms test helper, which is no longer needed. Stateful tests now call result.optimize() directly to run optimization passes.

Testing:
python unit tests
CI