### PR TITLE
[externalization] Add a two-step patch/sub-export API for module externalization

### DIFF
--- a/coreai_torch/__init__.py
+++ b/coreai_torch/__init__.py
@@ -17,7 +17,11 @@ from ._composite_declaration import generate_composite_decl
 from ._decomp import get_decomp_table
 from ._torch_metal_kernel import TorchMetalKernel
 from .converter import TorchConverter
-from .externalize import ExternalizeSpec
+from .externalize import (
+    ExternalizeSpec,
+    _patch_model_for_externalization,
+    _subexport_and_restore,
+)
 
 __all__ = [
     "__version__",
@@ -27,6 +31,8 @@ __all__ = [
     "TorchMetalKernel",
     "get_decomp_table",
     "generate_composite_decl",
+    "_patch_model_for_externalization",
+    "_subexport_and_restore",
 ]
 
 _TORCH_MAX_VERSION = "2.13.0"

--- a/coreai_torch/converter.py
+++ b/coreai_torch/converter.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Optional, cast
@@ -63,13 +63,11 @@ from ._utils import (
 from ._validate import validate_exported_program
 from .externalize import (
     ExternalizeSpec,
-    _ExportedModule,
-    _finalize_module_export,
-    _mark_externalize,
-    _prepare_externalized,
-    _PreparedModule,
+    _ExternalizedExportedProgram,
+    _find_marked_submodules,
+    _patch_model_for_externalization,
     _restore_externalized,
-    _torch_export_module,
+    _subexport_and_restore,
 )
 
 
@@ -86,6 +84,7 @@ class _StagedEntry:
     module: torch.nn.Module | None = None
     export_fn: Callable[..., Any] | None = None
     externalize_modules: list[type | ExternalizeSpec] | None = None
+    _externalized_exported_programs: list[_ExternalizedExportedProgram] | None = None
 
 
 class Context(_CoreAIAuthoringContext):
@@ -182,7 +181,7 @@ class TorchConverter:
         self._externalized_lowerings: dict[str, Callable[..., Any]] = {}
 
         # externalized modules
-        self._externalized_modules: list[_ExportedModule] = []
+        self._externalized_exported_programs: list[_ExternalizedExportedProgram] = []
 
         self.user_input_names: Sequence[str] = []
         self.user_output_names: Sequence[str] = []
@@ -201,19 +200,23 @@ class TorchConverter:
         output_names: Sequence[str] | None = None,
         state_names: Sequence[str] | None = None,
         entrypoint_name: str = "main",
+        _externalized_exported_programs: list[_ExternalizedExportedProgram]
+        | None = None,
     ) -> Self:
-        """Stage a pre-exported ExportedProgram for conversion.
+        """Stage a pre-exported ``ExportedProgram`` for conversion.
 
         The caller is responsible for calling ``torch.export.export()`` and
         ``run_decompositions()`` before passing the program.
 
         Args:
-            input_names: Non-stateful forward() arg names only.
-            output_names: Return value names only (not mutation outputs).
-            state_names: One name per state, applied to both input and
-                mutation output. Order: buffers (registration order), then
-                mutated user inputs (signature order). Defaults to FX
-                placeholder names when not provided.
+            input_names: Non-stateful ``forward()`` arg names.
+            output_names: Return value names (not mutation outputs).
+            state_names: One name per state (buffers then mutated inputs).
+                Defaults to FX placeholder names.
+            _externalized_exported_programs: Result of
+                :func:`coreai_torch.externalize._subexport_and_restore`.
+                When set, emits composite ``coreai.graph``s for the patched
+                call sites in ``exported_program``.
 
         Returns ``self`` for chaining.
         """
@@ -233,6 +236,7 @@ class TorchConverter:
                 output_names=output_names or [],
                 state_names=state_names or [],
                 entrypoint_name=entrypoint_name,
+                _externalized_exported_programs=_externalized_exported_programs,
             )
         )
         return self
@@ -303,65 +307,43 @@ class TorchConverter:
         )
         return self
 
-    def _run_externalize_pipeline(self) -> None:
-        """Mark, re-export, and export each externalized submodule.
+    def _run_externalize_pipeline_from_module(self) -> None:
+        """Externalize from a live ``nn.Module`` + ``export_fn`` (Phases 1-3).
 
-        The model is patched temporarily and always restored, even on error.
-
-        Steps:
-        1. Mark matching submodules with custom ops via ``_mark_externalize``.
-        2. Re-export the whole model (now containing custom op calls).
-        3. For each marked submodule, export it standalone and decompose.
-        4. Store results in ``self._externalized_modules`` and update
-           ``self.exported_program`` to the re-exported whole-model program.
+        Used by :meth:`add_pytorch_module`. Marks matching submodules with
+        custom ops, re-exports the whole model, then delegates Phases 2-3
+        (sub-export) to :func:`_subexport_and_restore`, which stashes the
+        results in ``self._externalized_exported_programs`` for
+        :meth:`_perform_externalization` to emit and restores the model
+        patch (``try/finally``) internally.
         """
         assert self._module is not None
         assert self._export_fn is not None
         assert self._externalize_modules is not None
 
-        _mark_externalize(self._module, self._externalize_modules)
+        _patch_model_for_externalization(self._module, self._externalize_modules)
 
         try:
-            # Re-export after marking — failure here is our bug, not the user's
-            try:
-                with self._progress_bar.status("Re-exporting for externalization..."):
-                    whole_ep: ExportedProgram = self._export_fn(self._module)
-                inject_subbyte_tensors(whole_ep)
-            except Exception as e:
-                raise RuntimeError(
-                    f"Internal error: re-export after externalization failed: {e}\n"
-                    f"This is a coreai-torch bug. Please report it."
-                ) from e
+            with self._progress_bar.status("Re-exporting for externalization..."):
+                whole_ep: ExportedProgram = self._export_fn(self._module)
+            inject_subbyte_tensors(whole_ep)
+        except Exception as e:
+            # Re-export after marking failed — our bug, not the user's. Restore
+            # here since _subexport_and_restore never gets a chance to.
+            _restore_externalized(_find_marked_submodules(self._module))
+            raise RuntimeError(
+                f"Internal error: re-export after externalization failed: {e}\n"
+                f"This is a coreai-torch bug. Please report it."
+            ) from e
 
-            # Prepare and export each submodule
-            preps: Iterator[_PreparedModule] = _prepare_externalized(
-                self._module, whole_ep
-            )
-            exts: list[_ExportedModule] = []
-            with self._progress_bar.stream("Externalizing submodules") as advance:
-                for prep in preps:
-                    try:
-                        inner_ep = _torch_export_module(prep)
-                    except Exception as e:
-                        raise RuntimeError(
-                            f"Internal error: failed to export submodule "
-                            f"'{prep.name}': {e}\n"
-                            f"This is a coreai-torch bug. Please report it."
-                        ) from e
-
-                    # Use the standard decomposition table for inner modules.
-                    # The user's export_fn may preserve composite ops like
-                    # aten.scaled_dot_product_attention so they survive in the
-                    # *whole-model* graph for externalization detection.
-                    # Inside the externalized body those ops must be decomposed.
-                    inner_ep = inner_ep.run_decompositions()
-                    exts.append(_finalize_module_export(prep, inner_ep))
-                    advance()
-
-            self._externalized_modules = exts
-            self.exported_program = whole_ep
-        finally:
-            _restore_externalized(self._module)
+        # The user's export_fn may preserve composite ops like
+        # aten.scaled_dot_product_attention so they survive in the
+        # *whole-model* graph for externalization detection; decompositions
+        # inside each submodule's own export happen in _subexport_and_restore.
+        self._externalized_exported_programs = _subexport_and_restore(
+            self._module, whole_ep, progress_bar=self._progress_bar
+        )
+        self.exported_program = whole_ep
 
     def _perform_externalization(self, context) -> None:
         """Emit externalized submodule graphs and register their lowerings.
@@ -369,7 +351,7 @@ class TorchConverter:
         Modules are processed deepest-first so that inner lowerings are
         available when parent graphs are built (nested externalization).
 
-        For each :class:`_ExportedModule`, this method:
+        For each :class:`_ExternalizedExportedProgram`, this method:
 
         1. Temporarily swaps ``self.exported_program`` to the submodule's export.
         2. Builds a ``coreai.graph noinline`` via :meth:`_get_graph_op`
@@ -377,15 +359,15 @@ class TorchConverter:
         3. Registers a lowering that maps the custom op to ``coreai.invoke``.
         4. Restores the whole-model program.
         """
-        if not self._externalized_modules:
+        if not self._externalized_exported_programs:
             return
 
         whole_program: ExportedProgram = self.exported_program
 
         # Process deepest modules first so their lowerings exist
         # when parent modules are built.
-        sorted_exts: list[_ExportedModule] = sorted(
-            self._externalized_modules,
+        sorted_exts: list[_ExternalizedExportedProgram] = sorted(
+            self._externalized_exported_programs,
             key=lambda ext: ext.name.count("."),
             reverse=True,
         )
@@ -941,7 +923,14 @@ class TorchConverter:
                             self._module = entry.module
                             self._export_fn = entry.export_fn
                             self._externalize_modules = entry.externalize_modules
-                            self._run_externalize_pipeline()
+                            self._run_externalize_pipeline_from_module()
+                            self._perform_externalization(module.context)
+
+                        # Handle externalization for pre-marked ExportedProgram path
+                        elif entry._externalized_exported_programs is not None:
+                            self._externalized_exported_programs = (
+                                entry._externalized_exported_programs
+                            )
                             self._perform_externalization(module.context)
 
                         self._get_graph_op(
@@ -971,7 +960,7 @@ class TorchConverter:
             parts = [f"    {entry.entrypoint_name}: {kind} {inputs} -> {outputs}"]
             if entry.externalize_modules:
                 names = [
-                    s.module_type.__name__
+                    s.target_class.__name__
                     if isinstance(s, ExternalizeSpec)
                     else s.__name__
                     for s in entry.externalize_modules

--- a/coreai_torch/externalize.py
+++ b/coreai_torch/externalize.py
@@ -8,24 +8,22 @@
 Implementation Details
 ======================
 
-The externalize pipeline runs in ``to_coreai()`` when ``externalize_modules``
-is provided. It works in five phases:
+The externalize pipeline works in four phases:
 
-Phase 1: Mark & Re-export (``_mark_externalize``)
---------------------------------------------------
-1. Walk ``model.named_modules()`` and for each matching instance: resolve the
-   module path, sanitize the op name, save the original forward as
-   ``_original_forward``, register a ``torch.library.custom_op`` from the
-   submodule's ``forward``, register the original forward as the fake
-   implementation via ``register_fake``, patch ``submodule.forward`` to call
-   the custom op, and stamp ``_externalize_config = ExternalizeSpec(...)``
-   on the module.
-2. Re-export via ``export_fn(model)`` and ``run_decompositions(decomp_table)``.
-   The FX graph now contains opaque ``call_function`` nodes for each custom op
-   call site.
+Phase 1: Mark (``_patch_model_for_externalization`` / ``_mark_externalize``)
+--------------------------------------------------------------------
+Called immediately when the user calls ``_patch_model_for_externalization(model, targets)``.
+Walks ``model.named_modules()`` and for each matching instance: resolves the
+module path, sanitizes the op name, saves the original forward as
+``_original_forward``, registers a ``torch.library.custom_op`` from the
+submodule's ``forward``, registers the original forward as the fake
+implementation via ``register_fake``, patches ``submodule.forward`` to call
+the custom op, and stamps ``_externalize_config = ExternalizeSpec(...)`` on
+the module.  The model is left patched until ``_subexport_and_restore(model, ep)``
+is called.
 
-Phase 2: Prepare (``_prepare_externalized`` / ``_prepare_module_export``)
--------------------------------------------------------------------------
+Phase 2: Prepare (``_PreparedModules`` / ``_prepare_module_export``)
+----------------------------------------------------------------------
 ``_PreparedModules.__iter__`` yields ``_PreparedModule`` objects in
 shallowest-first order. For each marked module, ``_prepare_module_export``
 finds all FX nodes for this custom op, restores the original forward, reads
@@ -40,18 +38,19 @@ from the ``ExportedProgram``'s graph signature (parameters/buffers use their
 target attribute name, user inputs use their forward parameter name). The
 exported program is then decomposed via ``run_decompositions()``.
 
+Phases 2 and 3 run inside ``_subexport_and_restore(model, ep)``, a standalone
+function that rediscovers marked submodules by walking ``model`` for the
+stamps left by ``_patch_model_for_externalization`` (no separate handle object is
+kept). It returns the resulting ``list[_ExternalizedExportedProgram]`` and restores the
+model in a ``finally`` block. Pass that list to
+``TorchConverter.add_exported_program(ep, _externalized_exported_programs=...)``.
+
 Phase 4: Emit Core AI IR (``_perform_externalization``)
 ------------------------------------------------------
-Process ``_ExportedModule`` objects deepest-first so inner lowerings exist
+Process ``_ExternalizedExportedProgram`` objects deepest-first so inner lowerings exist
 when parent graphs are built. For each module, build a ``coreai.GraphOp``
 (``noinline`` for all, ``private`` + ``composite_decl`` for composite ops)
 and register per-node lowerings keyed by FX node name.
-
-Phase 5: Cleanup (``_restore_externalized``)
----------------------------------------------
-Remove all markers (``_original_forward``, ``_externalize_name``,
-``_externalize_op_name``, ``_externalize_config``) from every patched module.
-The user's model is left unmodified.
 """
 
 from __future__ import annotations
@@ -59,6 +58,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from collections.abc import Iterator
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
@@ -71,10 +71,12 @@ from torch.export.graph_signature import InputKind, OutputKind
 
 from ._utils import (
     _EXTERNALIZE_NAMESPACE,
+    _ancestor_paths,
     _dynamic_shapes_from_node,
     _fake_inputs_from_node,
     _find_all_custom_op_nodes,
     _find_program_for,
+    _ProgressBar,
     _resolve_name,
     _sanitize_op_name,
 )
@@ -112,7 +114,7 @@ class ExternalizeSpec:
 
 
 @dataclass
-class _ExportedModule:
+class _ExternalizedExportedProgram:
     """Final export result for one call site, ready for lowering (step 5).
 
     Produced by ``_finalize_module_export``. Each instance becomes one
@@ -242,8 +244,8 @@ def _torch_export_module(
 def _finalize_module_export(
     prep: _PreparedModule,
     exported_program: ExportedProgram,
-) -> _ExportedModule:
-    """Step 5: Pack a ``_PreparedModule`` and its exported program into an ``_ExportedModule``.
+) -> _ExternalizedExportedProgram:
+    """Step 5: Pack a ``_PreparedModule`` and its exported program into an ``_ExternalizedExportedProgram``.
 
     Also registers the program in the session so nested children can find
     their parent's custom op nodes.
@@ -252,9 +254,16 @@ def _finalize_module_export(
         prep._program_registry._programs[prep.name] = exported_program
         # Also register under the original module path so nested children
         # can find their parent via _find_program_for / _ancestor_paths.
+        # When a module instance has multiple call sites, this key is
+        # overwritten once per call site (last-writer-wins). That's safe
+        # only because every call site's sub-export carries the same set of
+        # nested custom-op nodes for this instance's children — if a future
+        # change ever produced call-site-specific sub-exports (e.g. differing
+        # graph shapes per site), this would silently pick an arbitrary
+        # parent EP for nested lookups.
         if prep.module_path != prep.name:
             prep._program_registry._programs[prep.module_path] = exported_program
-    return _ExportedModule(
+    return _ExternalizedExportedProgram(
         name=prep.name,
         op_name=prep.op_name,
         exported_program=exported_program,
@@ -269,16 +278,32 @@ def _finalize_module_export(
 def _prepare_module(
     model: torch.nn.Module,
     submodule: torch.nn.Module,
+    op_name_suffix: str,
 ) -> None:
     """Step 1b: Replace ``submodule.forward`` with a ``torch.library.custom_op``.
 
     Called by ``_mark_externalize`` for each matching submodule. Saves the
     original forward as ``_original_forward`` and attaches ``_externalize_name``
     and ``_externalize_op_name`` markers for later steps.
+
+    ``op_name_suffix`` (shared by every submodule marked in one
+    ``_patch_model_for_externalization`` call) is appended to the sanitized module
+    path to form the ``torch.library`` op name. PyTorch library registrations
+    are **process-global** and keyed only by this name, so without a per-call
+    suffix, marking two different models whose submodules resolve to the same
+    dotted path (e.g. both have a ``.norm``) would collide even though each
+    call individually restores its own patches.
     """
     name = _resolve_name(model, submodule)
-    op_name = _sanitize_op_name(name)
+    op_name = f"{_sanitize_op_name(name)}_{op_name_suffix}"
     qualified_name = f"{_EXTERNALIZE_NAMESPACE}::{op_name}"
+
+    if hasattr(submodule, "_original_forward"):
+        raise RuntimeError(
+            f"submodule '{name}' is already marked for externalization "
+            f"(missing a restore from a prior _patch_model_for_externalization call). "
+            f"Restore it via _subexport_and_restore before re-marking."
+        )
 
     original_forward = submodule.forward
     submodule._original_forward = original_forward  # type: ignore[attr-defined]
@@ -289,6 +314,83 @@ def _prepare_module(
         qualified_name, original_forward, mutates_args=()
     )
     torch.library.register_fake(qualified_name, original_forward)
+    # torch.library registrations are process-global and have no
+    # unregistration API, so this custom_op/register_fake/register_autograd
+    # triple stays registered for the rest of the process's lifetime. The
+    # per-call op_name_suffix keeps names unique across calls (no collisions),
+    # but many convert cycles in one long-lived process will accumulate
+    # registrations — an intentional, unavoidable tradeoff, not a bug.
+
+    def _setup_context_impl(ctx, inputs, keyword_only_inputs, output):  # type: ignore[no-untyped-def]
+        ctx.save_for_backward(
+            *[x.detach().clone() for x in inputs if isinstance(x, torch.Tensor)]
+        )
+        ctx.keyword_only_inputs = keyword_only_inputs
+        ctx.non_tensor_inputs = [
+            (i, x) for i, x in enumerate(inputs) if not isinstance(x, torch.Tensor)
+        ]
+        ctx.input_requires_grad = [
+            isinstance(x, torch.Tensor) and x.requires_grad for x in inputs
+        ]
+
+    # torch.library.register_autograd fixes the setup_context calling
+    # convention per-op based on the op's schema: ops with a keyword-only
+    # parameter (i.e. the wrapped forward has one after a bare `*`) are
+    # always called as (ctx, inputs, keyword_only_inputs, output); all
+    # other ops are always called as (ctx, inputs, output). This is
+    # decided once per op, not per call, so we must pick the matching
+    # signature up front rather than hardcode either form.
+    has_kwonly_args = any(
+        p.kind is inspect.Parameter.KEYWORD_ONLY
+        for p in inspect.signature(original_forward).parameters.values()
+    )
+
+    if has_kwonly_args:
+
+        def _setup_context(ctx, inputs, keyword_only_inputs, output):  # type: ignore[no-untyped-def]
+            _setup_context_impl(ctx, inputs, keyword_only_inputs, output)
+    else:
+
+        def _setup_context(ctx, inputs, output):  # type: ignore[no-untyped-def]
+            _setup_context_impl(ctx, inputs, {}, output)
+
+    def _backward(ctx, *grad_outputs):  # type: ignore[no-untyped-def]
+        # Re-runs original_forward under enable_grad to reconstruct the inner
+        # autograd graph. Cost is ~1.5x a normal backward (forward runs twice).
+        # Stateful submodules (BN running stats, dropout, RNG) are observed
+        # twice per training step — _patch_model_for_externalization is not a
+        # transparent drop-in for training loops with stateful submodules.
+        saved = list(ctx.saved_tensors)
+        non_tensor_map = dict(ctx.non_tensor_inputs)
+        # Reconstruct the positional input list interleaving tensors and
+        # non-tensors. Keyword-only inputs are kept separate (see
+        # ctx.keyword_only_inputs) and are not differentiated — torch
+        # disallows kwarg-only Tensor args for register_autograd, so they
+        # are always plain config values.
+        inputs: list[Any] = []
+        tensor_iter = iter(saved)
+        for i, needs_grad in enumerate(ctx.input_requires_grad):
+            if i in non_tensor_map:
+                inputs.append(non_tensor_map[i])
+            else:
+                t = next(tensor_iter)
+                inputs.append(t.detach().requires_grad_(needs_grad))
+
+        with torch.enable_grad():
+            out = original_forward(*inputs, **ctx.keyword_only_inputs)
+
+        torch.autograd.backward(
+            [out] if isinstance(out, torch.Tensor) else list(out),
+            grad_outputs,
+        )
+        return tuple(
+            x.grad if isinstance(x, torch.Tensor) and x.requires_grad else None
+            for x in inputs
+        )
+
+    torch.library.register_autograd(
+        qualified_name, _backward, setup_context=_setup_context
+    )
 
     def patched_forward(*args, _op=custom_op_fn, **kwargs):  # type: ignore[no-untyped-def]
         return _op(*args, **kwargs)
@@ -353,6 +455,21 @@ def _prepare_module_export(
     return preps
 
 
+def _find_marked_submodules(model: torch.nn.Module) -> list[torch.nn.Module]:
+    """Walk ``model`` and collect submodules previously patched by ``_patch_model_for_externalization``.
+
+    Marked submodules are identified by the ``_externalize_name`` stamp left
+    by ``_prepare_module`` — there is no separate handle object tracking
+    them, so ``_subexport_and_restore`` rediscovers them this way each time
+    it runs.
+    """
+    return [
+        mod
+        for name, mod in model.named_modules()
+        if name and hasattr(mod, "_externalize_name")
+    ]
+
+
 def _mark_externalize(
     module: torch.nn.Module,
     targets: list[type | ExternalizeSpec],
@@ -373,16 +490,21 @@ def _mark_externalize(
         ExternalizeSpec(target_class=t) if isinstance(t, type) else t for t in targets
     ]
     matched = [False] * len(configs)
+    op_name_suffix = uuid4().hex[:8]
 
-    for name, mod in module.named_modules():
-        if not name:
-            continue
-        for i, config in enumerate(configs):
-            if isinstance(mod, config.target_class):
-                _prepare_module(module, mod)
-                mod._externalize_config = config  # type: ignore[attr-defined]
-                matched[i] = True
-                break
+    try:
+        for name, mod in module.named_modules():
+            if not name:
+                continue
+            for i, config in enumerate(configs):
+                if isinstance(mod, config.target_class):
+                    _prepare_module(module, mod, op_name_suffix)
+                    mod._externalize_config = config  # type: ignore[attr-defined]
+                    matched[i] = True
+                    break
+    except Exception:
+        _restore_externalized(_find_marked_submodules(module))
+        raise
 
     unmatched = [
         configs[i].target_class.__name__ for i, ok in enumerate(matched) if not ok
@@ -412,22 +534,17 @@ class _PreparedModules:
         model: torch.nn.Module,
         exported_program: ExportedProgram,
     ) -> None:
-        self._model = model
         self._programs: dict[str, ExportedProgram] = {"": exported_program}
-        self._wrapped: list[tuple[str, torch.nn.Module]] = sorted(
-            (
-                (name, mod)
-                for name, mod in model.named_modules()
-                if hasattr(mod, "_externalize_name")
-            ),
-            key=lambda x: x[0].count("."),
+        self._wrapped: list[torch.nn.Module] = sorted(
+            _find_marked_submodules(model),
+            key=lambda mod: mod._externalize_name.count("."),  # type: ignore[attr-defined]
         )
 
     def __len__(self) -> int:
         return len(self._wrapped)
 
     def __iter__(self) -> Iterator[_PreparedModule]:
-        for _name, mod in self._wrapped:
+        for mod in self._wrapped:
             name: str = mod._externalize_name  # type: ignore[attr-defined]
             op_name: str = mod._externalize_op_name  # type: ignore[attr-defined]
             parent_ep = _find_program_for(name, op_name, self._programs)
@@ -435,12 +552,12 @@ class _PreparedModules:
                 # Marked submodule is not invoked in the exported graph.
                 # Skip it; its forward will be restored by _restore_externalized.
                 warnings.warn(
-                    f"\n[WARN] coreai_torch.externalize: skipping unused submodule '{name}'.\n"
-                    f"       It matched an externalize_modules target class but is not "
-                    f"reachable from the exported graph.\n"
-                    f"       Action: remove it from the model passed to add_pytorch_module, "
-                    f"or ignore if intentional.\n",
-                    stacklevel=2,
+                    f"coreai_torch.externalize: skipping unused submodule '{name}'. "
+                    f"It matched an externalize_modules target class but is not "
+                    f"reachable from the exported graph. Action: remove it from "
+                    f"the model passed to add_pytorch_module, or ignore if "
+                    f"intentional.",
+                    stacklevel=3,
                 )
                 continue
             preps = _prepare_module_export(mod, parent_ep)
@@ -449,25 +566,165 @@ class _PreparedModules:
                 yield prep
 
 
-def _prepare_externalized(
+def _drop_missing_call_sites(
     model: torch.nn.Module,
     exported_program: ExportedProgram,
-) -> Iterator[_PreparedModule]:
-    """Step 3 entry point: yield a ``_PreparedModule`` for every call site.
+) -> None:
+    """Warn on and restore top-level marked submodules absent from ``exported_program``.
 
-    Wraps ``_PreparedModules`` which handles shallowest-first ordering and
-    nested program lookup.
+    A marked submodule may not appear in ``exported_program`` if the model
+    was exported before ``_patch_model_for_externalization`` was called. Rather than
+    letting ``_prepare_module_export`` raise an opaque ``ValueError`` later,
+    warn and restore it (and any of its nested marked children, whose call
+    sites only exist inside the missing parent's own sub-export) in place —
+    the next ``_find_marked_submodules(model)`` call naturally excludes them.
+
+    Only top-level marked modules are checked directly; nested ones do not
+    appear in the top-level ``exported_program`` — they show up in the
+    sub-export of their enclosing module.
     """
-    return _PreparedModules(model, exported_program)
+    marked = _find_marked_submodules(model)
+    marked_names = {mod._externalize_name for mod in marked}  # type: ignore[attr-defined]
+
+    def _has_ancestor_in(name: str, names: set[str]) -> bool:
+        return any(ancestor in names for ancestor in _ancestor_paths(name))
+
+    missing_names = {
+        mod._externalize_name  # type: ignore[attr-defined]
+        for mod in marked
+        if not _has_ancestor_in(mod._externalize_name, marked_names)  # type: ignore[attr-defined]
+        and not _find_all_custom_op_nodes(exported_program, mod._externalize_op_name)  # type: ignore[attr-defined]
+    }
+    if not missing_names:
+        return
+
+    for name in sorted(missing_names):
+        warnings.warn(
+            f"No call sites found for externalized submodule '{name}' in "
+            "exported_program. It will not be externalized. The model may "
+            "have been exported before _patch_model_for_externalization was called.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    # Also drop nested modules whose top-level parent is absent — their
+    # call sites only appear in the parent's sub-export, which won't run.
+    to_remove = [
+        mod
+        for mod in marked
+        if mod._externalize_name in missing_names  # type: ignore[attr-defined]
+        or _has_ancestor_in(mod._externalize_name, missing_names)  # type: ignore[attr-defined]
+    ]
+    _restore_externalized(to_remove)
 
 
-def _restore_externalized(module: torch.nn.Module) -> None:
+def _subexport_and_restore(
+    model: torch.nn.Module,
+    exported_program: ExportedProgram,
+    *,
+    progress_bar: _ProgressBar | None = None,
+) -> list[_ExternalizedExportedProgram]:
+    """Run sub-export (Phases 2–3) and restore all forward patches.
+
+    Rediscovers the submodules ``_patch_model_for_externalization`` patched by
+    walking ``model`` for the stamps ``_prepare_module`` left behind, finds
+    every custom-op call site for each in ``exported_program``, runs
+    ``torch.export.export`` on each patched submodule standalone, and
+    returns the resulting :class:`_ExternalizedExportedProgram` list. Marked submodules
+    with no call site in ``exported_program`` are skipped with a
+    ``UserWarning`` rather than raising. The original ``forward`` methods
+    are always restored in a ``finally`` block regardless of whether the
+    export succeeds.
+
+    Calling this a second time on an already-restored ``model`` finds no
+    marked submodules and returns ``[]``.
+
+    Pass ``progress_bar`` (e.g. ``TorchConverter``'s own bar, from inside
+    a ``to_coreai()`` call) to report per-submodule progress; omit it to
+    run silently, which is the right default when calling this outside
+    such a context.
+
+    Pass the returned list to
+    :meth:`TorchConverter.add_exported_program`'s ``_externalized_exported_programs``
+    argument.
+    """
+    try:
+        _drop_missing_call_sites(model, exported_program)
+        preps = _PreparedModules(model, exported_program)
+        exts: list[_ExternalizedExportedProgram] = []
+        stream = (
+            progress_bar.stream("Externalizing submodules")
+            if progress_bar is not None
+            else nullcontext(None)
+        )
+        with stream as advance:
+            for prep in preps:
+                # By now exported_program (the whole model) already
+                # contained this submodule's custom-op call site, so a
+                # failure re-exporting it standalone is a coreai-torch
+                # bug, not a caller error.
+                try:
+                    inner_ep = _torch_export_module(prep)
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Internal error: failed to export submodule "
+                        f"'{prep.name}': {e}\n"
+                        f"This is a coreai-torch bug. Please report it."
+                    ) from e
+                inner_ep = inner_ep.run_decompositions()
+                exts.append(_finalize_module_export(prep, inner_ep))
+                if advance is not None:
+                    advance()
+        return exts
+    finally:
+        # _drop_missing_call_sites already restored the modules it dropped
+        # (and warned about them); restore everything still marked here.
+        _restore_externalized(_find_marked_submodules(model))
+
+
+def _patch_model_for_externalization(
+    model: torch.nn.Module,
+    targets: list[type | ExternalizeSpec],
+) -> None:
+    """Patch matching submodules immediately.
+
+    Each matching submodule's ``forward`` is replaced with a
+    ``torch.library.custom_op`` so that any export or quantization pass run
+    afterwards captures the call sites as opaque FX nodes that survive every
+    downstream transform. Patch details (original forward, op name, spec)
+    are stamped directly onto each matched submodule instance — there is no
+    separate handle object tracking them, and nothing is returned;
+    :func:`_subexport_and_restore` rediscovers marked submodules by walking
+    the model itself.
+
+    After exporting (or quantizing) the patched model, call
+    :func:`_subexport_and_restore` with the model and the resulting
+    ``ExportedProgram`` to get back a ``list[_ExternalizedExportedProgram]``, then pass
+    that to :meth:`TorchConverter.add_exported_program`::
+
+        _patch_model_for_externalization(model, [
+            ExternalizeSpec(RMSNorm, composite_op_name="rms_norm",
+                            composite_attrs=["eps"]),
+        ])
+        ep = my_export_or_quantize_pipeline(model)
+        _externalized_exported_programs = _subexport_and_restore(model, ep)
+
+        coreai_program = (
+            TorchConverter()
+            .add_exported_program(ep, _externalized_exported_programs=_externalized_exported_programs)
+            .to_coreai()
+        )
+    """
+    _mark_externalize(model, targets)
+
+
+def _restore_externalized(marked: list[torch.nn.Module]) -> None:
     """Step 6: Undo all patches from step 1.
 
     Restores original forward methods and removes all externalization markers.
     Called after the pipeline completes (or on error via ``finally``).
     """
-    for _name, mod in module.named_modules():
+    for mod in marked:
         original = getattr(mod, "_original_forward", None)
         if original is not None:
             mod.forward = original

--- a/coreai_torch/externalize.py
+++ b/coreai_torch/externalize.py
@@ -527,6 +527,14 @@ class _PreparedModules:
     Iterates marked submodules in shallowest-first order. For nested
     externalization, resolves the correct parent ``ExportedProgram`` so each
     submodule's custom op nodes can be found.
+
+    Note: this is the second of two "no call site" warning paths, and both are
+    live. :func:`_drop_missing_call_sites` runs first and handles *top-level*
+    marked submodules missing from the whole-model program (typically because
+    the model was exported before it was patched). ``__iter__`` handles the
+    *nested* case that the earlier check cannot see: a submodule whose parent
+    does have a call site, but which is itself absent from that parent's
+    sub-export — which only exists once iteration reaches the parent.
     """
 
     def __init__(
@@ -582,6 +590,11 @@ def _drop_missing_call_sites(
     Only top-level marked modules are checked directly; nested ones do not
     appear in the top-level ``exported_program`` — they show up in the
     sub-export of their enclosing module.
+
+    Nested submodules are therefore handled by the sibling warning path in
+    :meth:`_PreparedModules.__iter__` ("skipping unused submodule"), which can
+    only run once the enclosing module's sub-export exists. Both paths are
+    reachable; neither supersedes the other.
     """
     marked = _find_marked_submodules(model)
     marked_names = {mod._externalize_name for mod in marked}  # type: ignore[attr-defined]
@@ -635,6 +648,11 @@ def _subexport_and_restore(
     ``UserWarning`` rather than raising. The original ``forward`` methods
     are always restored in a ``finally`` block regardless of whether the
     export succeeds.
+
+    Marked submodules with no call site are skipped via one of two paths
+    depending on depth: :func:`_drop_missing_call_sites` for top-level ones,
+    :meth:`_PreparedModules.__iter__` for nested ones. See those docstrings
+    for why the split is necessary.
 
     Calling this a second time on an already-restored ``model`` finds no
     marked submodules and returns ``[]``.

--- a/coreai_torch/externalize.py
+++ b/coreai_torch/externalize.py
@@ -86,7 +86,7 @@ from ._utils import (
 class ExternalizeSpec:
     """User-facing config describing which submodule class to externalize.
 
-    Used by ``_mark_externalize`` (step 1) to identify matching submodules.
+    Used by ``_mark_externalize`` (Phase 1) to identify matching submodules.
 
     Args:
         target_class: ``nn.Module`` subclass to match (via ``isinstance``).
@@ -115,7 +115,7 @@ class ExternalizeSpec:
 
 @dataclass
 class _ExternalizedExportedProgram:
-    """Final export result for one call site, ready for lowering (step 5).
+    """Final export result for one call site, ready for lowering (Phase 3).
 
     Produced by ``_finalize_module_export``. Each instance becomes one
     ``coreai.graph noinline`` and its corresponding ``coreai.invoke`` lowering
@@ -136,7 +136,7 @@ class _ExternalizedExportedProgram:
 
 @dataclass
 class _PreparedModule:
-    """Intermediate state for one call site before ``torch.export`` (step 3).
+    """Intermediate state for one call site before ``torch.export`` (Phase 2).
 
     Produced by ``_prepare_module_export``. Holds the fake inputs, dynamic
     shapes, and composite metadata needed to run ``torch.export.export`` on
@@ -197,7 +197,7 @@ def _derive_composite_io_names(
 def _torch_export_module(
     prep: _PreparedModule,
 ) -> ExportedProgram:
-    """Step 4: Run ``torch.export.export`` on a single submodule call site.
+    """Phase 3: Run ``torch.export.export`` on a single submodule call site.
 
     Uses the ``_PreparedModule``'s fake inputs and dynamic shapes to export.
     After export, composite I/O names are derived from the graph signature.
@@ -245,7 +245,7 @@ def _finalize_module_export(
     prep: _PreparedModule,
     exported_program: ExportedProgram,
 ) -> _ExternalizedExportedProgram:
-    """Step 5: Pack a ``_PreparedModule`` and its exported program into an ``_ExternalizedExportedProgram``.
+    """Phase 3: Pack a ``_PreparedModule`` and its exported program into an ``_ExternalizedExportedProgram``.
 
     Also registers the program in the session so nested children can find
     their parent's custom op nodes.
@@ -280,7 +280,7 @@ def _prepare_module(
     submodule: torch.nn.Module,
     op_name_suffix: str,
 ) -> None:
-    """Step 1b: Replace ``submodule.forward`` with a ``torch.library.custom_op``.
+    """Phase 1: Replace ``submodule.forward`` with a ``torch.library.custom_op``.
 
     Called by ``_mark_externalize`` for each matching submodule. Saves the
     original forward as ``_original_forward`` and attaches ``_externalize_name``
@@ -402,7 +402,7 @@ def _prepare_module_export(
     submodule: torch.nn.Module,
     exported_program: ExportedProgram,
 ) -> list[_PreparedModule]:
-    """Step 3: Extract call-site info from the whole-model export for one submodule.
+    """Phase 2: Extract call-site info from the whole-model export for one submodule.
 
     Finds all FX nodes that call this submodule's custom op, extracts fake
     inputs and dynamic shapes from each, restores the original forward, and
@@ -474,7 +474,7 @@ def _mark_externalize(
     module: torch.nn.Module,
     targets: list[type | ExternalizeSpec],
 ) -> None:
-    """Step 1: Walk ``module`` and patch every matching submodule's forward.
+    """Phase 1: Walk ``module`` and patch every matching submodule's forward.
 
     For each submodule whose class matches a target, calls
     ``_prepare_module`` (replacing forward with a custom op) and stores
@@ -522,7 +522,7 @@ def _mark_externalize(
 
 
 class _PreparedModules:
-    """Iterator for step 3: yields one ``_PreparedModule`` per call site.
+    """Phase 2 iterator: yields one ``_PreparedModule`` per call site.
 
     Iterates marked submodules in shallowest-first order. For nested
     externalization, resolves the correct parent ``ExportedProgram`` so each
@@ -737,7 +737,7 @@ def _patch_model_for_externalization(
 
 
 def _restore_externalized(marked: list[torch.nn.Module]) -> None:
-    """Step 6: Undo all patches from step 1.
+    """Undo all patches from Phase 1.
 
     Restores original forward methods and removes all externalization markers.
     Called after the pipeline completes (or on error via ``finally``).

--- a/tests/test_externalize.py
+++ b/tests/test_externalize.py
@@ -22,7 +22,11 @@ from coreai_torch import ExternalizeSpec, TorchConverter, get_decomp_table
 from coreai_torch.composite_ops import SDPA, GatherMM, RMSNorm, RMSNormImpl
 from coreai_torch.externalize import (
     _derive_composite_io_names,
+    _find_marked_submodules,
+    _patch_model_for_externalization,
     _prepare_module,
+    _restore_externalized,
+    _subexport_and_restore,
 )
 
 from .utils import (
@@ -423,7 +427,7 @@ def test_wrap_module_invalid_submodule() -> None:
     model = Model().eval()
 
     with pytest.raises(ValueError, match="submodule not found in model"):
-        _prepare_module(model, nn.Linear(4, 4))
+        _prepare_module(model, nn.Linear(4, 4), "test")
 
 
 @pytest.mark.ir
@@ -2096,6 +2100,244 @@ async def test_externalize_partial_match_warns() -> None:
     await _validate_numerics(coreai_program, model, sample)
 
 
+def test_externalize_backward() -> None:
+    """Gradients flow through externalized submodules (register_autograd)."""
+
+    class Norm(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(8))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x * self.weight
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = Norm()
+            self.fc = nn.Linear(8, 1)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.norm(x))
+
+    torch.manual_seed(0)
+    model = Model().eval()
+    _patch_model_for_externalization(model, [Norm])
+
+    x = torch.randn(2, 8, requires_grad=True)
+    out = model(x)
+    out.sum().backward()
+
+    _restore_externalized(_find_marked_submodules(model))
+
+    assert x.grad is not None, "grad did not flow back to input"
+    assert model.norm.weight.grad is not None, "grad did not flow to norm.weight"
+    assert model.fc.weight.grad is not None, "grad did not flow to fc.weight"
+
+
+def test_externalize_no_call_sites_warns() -> None:
+    """EP exported from an unpatched model: warn and produce a flat conversion.
+
+    If the user exports the model before calling _patch_model_for_externalization,
+    the custom-op call sites are absent.  _subexport_and_restore should emit a
+    UserWarning and skip externalizing rather than raising.
+    """
+
+    class Norm(nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x / x.norm()
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = Norm()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.norm(x)
+
+    torch.manual_seed(0)
+    model = Model().eval()
+    sample = (torch.randn(2, 4),)
+
+    # Export BEFORE patching — no custom-op nodes in the graph.
+    ep = torch.export.export(model, args=sample).run_decompositions(get_decomp_table())
+    _patch_model_for_externalization(model, [Norm])
+
+    with pytest.warns(
+        UserWarning, match="No call sites found for externalized submodule 'norm'"
+    ):
+        externalized_exported_programs = _subexport_and_restore(model, ep)
+
+    program = (
+        TorchConverter()
+        .add_exported_program(
+            ep, _externalized_exported_programs=externalized_exported_programs
+        )
+        .to_coreai()
+    )
+
+    # Conversion still succeeds; no submodule graphs emitted.
+    assert program is not None
+    assert externalized_exported_programs == []
+
+
+@pytest.mark.ir
+def test_externalize_manual_subexport_workflow_ir() -> None:
+    """The manual patch -> external-tool -> sub-export -> convert workflow.
+
+    Mirrors the documented advanced path where the user drives export
+    themselves (e.g. through a quantizer) instead of handing the model to
+    ``add_pytorch_module``:
+
+        _patch_model_for_externalization(model, [spec])
+        ep = <external tool that exports the patched model>
+        externalized = _subexport_and_restore(model, ep)
+        TorchConverter().add_exported_program(
+            ep, _externalized_exported_programs=externalized
+        ).to_coreai()
+
+    Here the "external tool" is a passthrough export, standing in for a
+    quantizer, so the test pins the workflow contract rather than any
+    quantizer behavior: the custom-op call sites survive the caller's own
+    export, the model is left unpatched afterwards, and the submodule is
+    emitted as a composite op.
+    """
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = RMSNorm(dim=DIM)
+            self.fc = nn.Linear(DIM, DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.norm(x))
+
+    torch.manual_seed(42)
+    model = Model().eval()
+    sample = (torch.randn(2, DIM),)
+
+    # Phase 1: patch the marked submodules in place.
+    _patch_model_for_externalization(
+        model,
+        [
+            ExternalizeSpec(
+                target_class=RMSNormImpl,
+                composite_op_name="rms_norm",
+                composite_attrs=["axes", "eps", "version"],
+            )
+        ],
+    )
+
+    marked = _find_marked_submodules(model)
+    assert [mod._externalize_name for mod in marked] == ["norm.rmsnorm_impl"], (
+        "expected the nested RMSNormImpl to be the single marked submodule"
+    )
+    op_name = marked[0]._externalize_op_name
+
+    # Stand-in for `quantizer.prepare(model).calibrate(data).finalize()`: any
+    # caller-driven export of the still-patched model.
+    ep = torch.export.export(model, args=sample).run_decompositions(get_decomp_table())
+
+    # The custom-op call site survives the caller's export/transform passes,
+    # and the model is still patched at this point.
+    assert any(op_name in str(node.target) for node in ep.graph.nodes), (
+        f"custom op {op_name!r} did not survive the caller's export; "
+        f"targets were {[str(n.target) for n in ep.graph.nodes]}"
+    )
+    assert _find_marked_submodules(model), "model unpatched before sub-export"
+
+    # Phases 2-3: sub-export each marked submodule and restore the model.
+    externalized_exported_programs = _subexport_and_restore(model, ep)
+
+    assert len(externalized_exported_programs) == 1, (
+        f"expected one externalized submodule, got "
+        f"{len(externalized_exported_programs)}"
+    )
+    # _subexport_and_restore restores in a finally block, so the model is clean
+    # regardless of sub-export success.
+    assert _find_marked_submodules(model) == [], (
+        "model still patched after _subexport_and_restore"
+    )
+    assert isinstance(
+        model.norm.rmsnorm_impl(*(torch.randn(2, DIM),) * 2), torch.Tensor
+    )
+
+    coreai_program = (
+        TorchConverter()
+        .add_exported_program(
+            ep, _externalized_exported_programs=externalized_exported_programs
+        )
+        .to_coreai()
+    )
+
+    pattern = """
+    // CHECK: coreai.graph private noinline @norm.rmsnorm_impl_[[S:[a-f0-9]+]](
+    // CHECK-SAME: composite_decl = #coreai.composite_declaration<"rms_norm" =
+    // CHECK-SAME: input_names = ["input", "scale"]
+    // CHECK-SAME: op_attrs =
+    // CHECK-SAME: axes = -1 : si64
+    // CHECK-SAME: eps = 9.99999974E-6 : f32
+    // CHECK-SAME: version = 1 : si64
+    // CHECK-SAME: output_names = ["output"]
+    // CHECK: coreai.invoke @norm.rmsnorm_impl_[[S]](%{{.*}})
+    """
+    filecheck_pattern(str(coreai_program), check_file=pattern)
+
+
+async def test_externalize_manual_subexport_workflow() -> None:
+    """Numerics for the manual patch -> external-tool -> sub-export -> convert path.
+
+    Companion to :func:`test_externalize_manual_subexport_workflow_ir`: the IR
+    test pins the structure, this one compiles the result and checks the
+    externalized composite still computes the same values as the original
+    (restored) PyTorch model.
+    """
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = RMSNorm(dim=DIM)
+            self.fc = nn.Linear(DIM, DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.norm(x))
+
+    torch.manual_seed(42)
+    model = Model().eval()
+    sample = (torch.randn(2, DIM),)
+
+    _patch_model_for_externalization(
+        model,
+        [
+            ExternalizeSpec(
+                target_class=RMSNormImpl,
+                composite_op_name="rms_norm",
+                composite_attrs=["axes", "eps", "version"],
+            )
+        ],
+    )
+
+    # Stand-in for the caller's quantizer/export tool.
+    ep = torch.export.export(model, args=sample).run_decompositions(get_decomp_table())
+    externalized_exported_programs = _subexport_and_restore(model, ep)
+
+    assert len(externalized_exported_programs) == 1, (
+        f"expected one externalized submodule, got "
+        f"{len(externalized_exported_programs)}"
+    )
+
+    coreai_program = (
+        TorchConverter()
+        .add_exported_program(
+            ep, _externalized_exported_programs=externalized_exported_programs
+        )
+        .to_coreai()
+    )
+
+    # `model` is restored by now, so this compares against the unpatched module.
+    await _validate_numerics(coreai_program, model, sample)
+
+
 @pytest.mark.ir
 def test_externalize_three_level_nesting_ir() -> None:
     """IR check: Externalize at three levels of depth: grandchild, child, and each gets its own graph."""
@@ -3718,7 +3960,9 @@ def test_externalize_unused_submodule_ir() -> None:
     model = OuterModel().eval()
     sample = (torch.randn(2, 4),)
 
-    with pytest.warns(UserWarning, match="skipping unused submodule"):
+    with pytest.warns(
+        UserWarning, match="No call sites found for externalized submodule 'unused'"
+    ):
         converter = TorchConverter().add_pytorch_module(
             model,
             export_fn=lambda m: torch.export.export(m, args=sample).run_decompositions(
@@ -3777,7 +4021,9 @@ async def test_externalize_unused_submodule_numerics() -> None:
     model = OuterModel().eval()
     sample = (torch.randn(2, 4),)
 
-    with pytest.warns(UserWarning, match="skipping unused submodule"):
+    with pytest.warns(
+        UserWarning, match="No call sites found for externalized submodule 'unused'"
+    ):
         converter = TorchConverter().add_pytorch_module(
             model,
             export_fn=lambda m: torch.export.export(m, args=sample).run_decompositions(

--- a/tests/test_externalize.py
+++ b/tests/test_externalize.py
@@ -42,12 +42,13 @@ async def _validate_numerics(
     model: torch.nn.Module,
     sample: tuple[torch.Tensor, ...],
     input_names: tuple[str, ...] = ("x",),
+    function_name: str = "main",
 ) -> None:
     """Compile, run in Core AI runtime, and compare against PyTorch output."""
     with TemporaryDirectory(suffix=".aimodel") as tmp:
         asset = coreai_program.save_asset(Path(tmp))
         async with asset.executable() as ai_model:
-            rt_func = ai_model.load_function("main")
+            rt_func = ai_model.load_function(function_name)
             inputs = {
                 name: NDArray(tensor) for name, tensor in zip(input_names, sample)
             }
@@ -4034,3 +4035,71 @@ async def test_externalize_unused_submodule_numerics() -> None:
         coreai_program = converter.to_coreai()
 
     await _validate_numerics(coreai_program, model, sample)
+
+
+async def test_externalize_multiple_staged_entries_numerics() -> None:
+    """Two staged entries in one to_coreai(), only one using externalization.
+
+    ``TorchConverter._externalized_exported_programs`` is converter-level
+    state, but externalization is per-entry: only the entry that asked for it
+    may emit submodule graphs and ``coreai.invoke`` call sites. ``to_coreai``
+    resets that field per entry via ``_init_conversion_state()``, so the plain
+    ``add_exported_program`` entry must stay flat even though it is converted
+    in the same call as an externalized one.
+
+    Checking numerics on both entrypoints pins that invariant end to end: a
+    leak would duplicate the composite into ``plain`` and change its output.
+    """
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = RMSNorm(dim=DIM)
+            self.fc = nn.Linear(DIM, DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.norm(x))
+
+    class Plain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(DIM, DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.relu(self.fc(x))
+
+    torch.manual_seed(42)
+    model = Model().eval()
+    sample = (torch.randn(2, DIM),)
+
+    torch.manual_seed(7)
+    plain_model = Plain().eval()
+    plain_sample = (torch.randn(2, DIM),)
+    plain_ep = torch.export.export(plain_model, args=plain_sample).run_decompositions(
+        get_decomp_table()
+    )
+
+    coreai_program = (
+        TorchConverter()
+        .add_pytorch_module(
+            model,
+            export_fn=lambda m: torch.export.export(m, args=sample).run_decompositions(
+                get_decomp_table()
+            ),
+            externalize_modules=[
+                ExternalizeSpec(
+                    target_class=RMSNormImpl,
+                    composite_op_name="rms_norm",
+                    composite_attrs=["axes", "eps", "version"],
+                )
+            ],
+            entrypoint_name="with_ext",
+        )
+        .add_exported_program(plain_ep, entrypoint_name="plain")
+        .to_coreai()
+    )
+
+    await _validate_numerics(coreai_program, model, sample, function_name="with_ext")
+    await _validate_numerics(
+        coreai_program, plain_model, plain_sample, function_name="plain"
+    )


### PR DESCRIPTION
  Reworks module externalization — emitting an `nn.Module` subtree as a single Core AI composite op — into an explicit two-step API, and adds autograd support so gradients can flow through externalized submodules.

  The one-shot path is unchanged: `add_pytorch_module(model, export_fn=…, externalize_modules=[...])` still does everything. The new split exists for callers who must drive export themselves (e.g. a quantizer), so marking and sub-export can happen either side of their own passes:

  ```python
  _patch_model_for_externalization(model, [spec])
  ep = quantizer.prepare(model).calibrate(data).finalize()   # any caller-driven export
  externalized = _subexport_and_restore(model, ep)

  program = (
      TorchConverter()
      .add_exported_program(ep, _externalized_exported_programs=externalized)
      .to_coreai()
  )
```
  Changes

  - Pipeline documented as four phases: Mark → Prepare → Export → Emit. Restore is folded
  into _subexport_and_restore's finally, so the model is always left unpatched.
  - register_autograd: backward through an externalized submodule now works.