### PR TITLE
[workflow] Enable trusted publishing 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,15 +139,13 @@ jobs:
       id-token: write # mint the OIDC token PyPI validates for Trusted Publishing
       contents: read
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: false
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        # `always` requires Trusted Publishing (OIDC) — no fallback to tokens.
-        run: uv publish --trusted-publishing always
+        # Uploads everything in dist/ (the action's default `packages-dir`). No
+        # `password` is supplied, so the only way it can authenticate is the OIDC
+        # token above. PEP 740 attestations are on by default.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
   # ── Build the exact wheel + sdist that will be smoke-tested and published. ──
   build:
     name: Build distributions
+    # PyPI Trusted Publishing only accepts OIDC tokens minted by github.com, so a
+    # run hosted anywhere else can never publish. Dry runs still work on any
+    # github.com clone, forks included.
+    if: github.server_url == 'https://github.com'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -71,6 +75,12 @@ jobs:
           fi
       - name: Build wheel and sdist
         run: uv build
+      - name: Rebuild the wheel from the sdist
+        # The sdist is published too, and only the wheel is installed and imported
+        # by smoke-test. Rebuilding from the sdist fails if MANIFEST.in omits a
+        # file the build needs. Built into a scratch dir so dist/ stays exactly
+        # what `uv build` produced.
+        run: uv build --wheel dist/coreai_torch-*.tar.gz --out-dir "${RUNNER_TEMP}/sdist-wheel"
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -79,10 +89,10 @@ jobs:
           if-no-files-found: error
 
   # ── Smoke test the exact built wheel via `scripts/smoke_test_wheel.sh`. ──
-  # Reuses the repo's smoke script but with `--no-build`, so it installs the
-  # downloaded artifact instead of rebuilding — we test the bytes we are about
-  # to publish. One matrix leg per supported Python version, since the script
-  # installs runtime deps only and thus catches missing dependency declarations.
+  # `--no-build` installs the downloaded wheel instead of rebuilding, so the
+  # bytes we import are the ones we publish. The script installs runtime deps
+  # only, which is what catches missing dependency declarations. The sdist is
+  # covered by the rebuild step in `build`.
   smoke-test:
     name: Smoke test wheel (Python ${{ matrix.python }})
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,143 @@
+name: Release
+
+run-name: 'Release ${{ github.ref_name }} · @${{ github.actor }}'
+
+# Publishing to PyPI uses Trusted Publishing (OIDC) — no API token is stored.
+# A release manager pushes a `vMAJOR.MINOR.PATCH` tag; the `build` and
+# `smoke-test` jobs run automatically, then the `publish` job pauses on the
+# `pypi` GitHub environment until a reviewer approves it. That environment's
+# protection rules (required reviewers, prevent-self-review so the tag pusher
+# can't approve their own release, and a wait timer) live in the repo's
+# Environment settings, not in this file.
+#
+# One-time setup is documented in RELEASE.md ("Trusted Publishing setup").
+on:
+  push:
+    tags:
+      # Strictly vMAJOR.MINOR.PATCH with numeric parts (e.g. v0.4.1). This is a
+      # glob, not a regex: `.` is a literal dot and `[0-9]` a digit range. The
+      # filter must match the entire tag, so pre-releases (v1.2.3rc1 — the
+      # trailing `rc1` is left unmatched) and other non-release tags never start
+      # the release run. The `pypi` environment tag rule and approval gate are
+      # secondary controls; the version guard below is the final backstop.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  # Manual dry run: builds and smoke-tests the current ref but never publishes
+  # (the publish job is gated to tag pushes). Trigger from the Actions tab
+  # ("Release" -> "Run workflow") or `gh workflow run release.yml --ref <branch>`.
+  workflow_dispatch:
+
+# Least privilege by default; the publish job opts into `id-token: write`.
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize releases per tag and never cancel an in-flight publish.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Build the exact wheel + sdist that will be smoke-tested and published. ──
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Verify the tag matches the package version
+        # The published version comes from coreai_torch/__version__.py (via
+        # `[tool.setuptools.dynamic]`), not the tag. Fail early if they disagree
+        # so we never publish a mismatched or duplicate version — PyPI uploads
+        # are immutable and cannot be overwritten or replaced.
+        # Skipped on manual dry runs, where the ref is a branch, not a vX.Y.Z tag.
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="$(sed -n 's/.*__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' coreai_torch/__version__.py)"
+          echo "tag=${tag}  package version=${version}"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read __version__ from coreai_torch/__version__.py"
+            exit 1
+          fi
+          if [ "${tag}" != "v${version}" ]; then
+            echo "::error::Tag ${tag} does not match package version v${version} (coreai_torch/__version__.py). Bump __version__ to match the tag, or tag the right commit."
+            exit 1
+          fi
+      - name: Build wheel and sdist
+        run: uv build
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  # ── Smoke test the exact built wheel via `scripts/smoke_test_wheel.sh`. ──
+  # Reuses the repo's smoke script but with `--no-build`, so it installs the
+  # downloaded artifact instead of rebuilding — we test the bytes we are about
+  # to publish. One matrix leg per supported Python version, since the script
+  # installs runtime deps only and thus catches missing dependency declarations.
+  smoke-test:
+    name: Smoke test wheel (Python ${{ matrix.python }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep in sync with PYTHON_VERSIONS in scripts/smoke_test_wheel.sh and
+        # `requires-python` in pyproject.toml.
+        python: ['3.11', '3.12', '3.13']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Smoke test the built wheel
+        run: ./scripts/smoke_test_wheel.sh --no-build --python ${{ matrix.python }}
+
+  # ── Publish to PyPI via Trusted Publishing. Only this job holds `id-token`. ──
+  # It builds nothing and runs no project code: it just downloads the vetted
+  # artifact and uploads it, keeping build/test dependencies out of the
+  # OIDC-privileged job.
+  publish:
+    name: Publish to PyPI
+    needs: [build, smoke-test]
+    # Publish only on a tag push (never on a manual dry run) and never from forks.
+    if: github.event_name == 'push' && github.repository == 'apple/coreai-torch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/coreai-torch
+    permissions:
+      id-token: write # mint the OIDC token PyPI validates for Trusted Publishing
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        # `always` requires Trusted Publishing (OIDC) — no fallback to tokens.
+        run: uv publish --trusted-publishing always

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,85 @@
+# Release Guide
+
+`coreai-torch` is published to [PyPI](https://pypi.org/p/coreai-torch) by
+`.github/workflows/release.yml`, which uses PyPI
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/): the workflow
+authenticates with a short-lived OIDC token minted by GitHub Actions for that
+one job, so no long-lived API token is stored in the repo or in an org secret.
+
+## Cutting a release
+
+1. On a release branch, pin dependencies, bump `__version__` in
+   `coreai_torch/__version__.py`, update the docs version metadata, and get the
+   PR reviewed and merged. `/release stage1` walks these checks.
+2. Tag the merge commit `vMAJOR.MINOR.PATCH` — matching `__version__` exactly —
+   and push the tag:
+
+   ```bash
+   git tag v0.5.0 <merge-sha>
+   git push origin v0.5.0
+   ```
+
+3. Pushing the tag starts the `Release` workflow. `build` verifies the tag
+   matches `__version__` and builds the wheel and sdist; `smoke-test` installs
+   that wheel into a clean venv on each supported Python version and imports the
+   public API.
+4. `publish` then waits on the `pypi` GitHub environment. A release manager other
+   than the tag pusher approves it, and the vetted artifact is uploaded to PyPI.
+5. Deploy the docs: `./docs/deploy.sh` and `./docs/deploy.sh --remote pie`.
+
+To exercise the build and smoke test without publishing, run the workflow
+manually — `gh workflow run release.yml --ref <branch>`. The `publish` job is
+gated to tag pushes, so a dry run can never upload.
+
+Nothing about a release is done from a laptop: the artifact PyPI receives is
+built and tested by the workflow, from the tagged commit, and no developer
+holds a credential that can upload it.
+
+## Trusted Publishing setup
+
+One-time configuration, already in place for `apple/coreai-torch`. Recorded here
+so it can be audited or rebuilt.
+
+### On PyPI
+
+As an owner of the `coreai-torch` project, under **Manage project → Publishing →
+Add a new publisher → GitHub**:
+
+| Field             | Value                |
+| ----------------- | -------------------- |
+| Owner             | `apple`              |
+| Repository name   | `coreai-torch`       |
+| Workflow name     | `release.yml`        |
+| Environment name  | `pypi`               |
+
+The environment name is not optional here. Without it, *any* workflow in the
+repo named `release.yml` can publish; with it, PyPI additionally requires the
+OIDC token to assert the `pypi` environment, which is where the approval gate
+lives.
+
+For a project that does not exist on PyPI yet, the same form is available as a
+**pending publisher** from your account's Publishing page; the project is
+created on first successful upload.
+
+### On GitHub
+
+Under **Settings → Environments → New environment → `pypi`**:
+
+- **Required reviewers**: the release managers team, with **prevent
+  self-review** enabled — so the person who pushed the tag cannot approve their
+  own release.
+- **Wait timer**: 15 minutes, leaving time to cancel a run started by mistake.
+- **Deployment branches and tags**: restrict to the tag pattern `v*.*.*`, so a
+  run from a branch cannot reach the environment even if the workflow gate is
+  ever loosened.
+
+No secret is added to the environment. The `id-token: write` permission in the
+`publish` job is what lets it mint the OIDC token, and it is scoped to that job
+alone.
+
+## Internal publishing
+
+Trusted Publishing covers PyPI only. Publishing to Apple's internal Artifactory
+index still uses `scripts/release.sh` with `UV_PUBLISH_USERNAME` /
+`UV_PUBLISH_PASSWORD`; pass `--skip-publish` when the PyPI upload is handled by
+the workflow.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,45 +38,17 @@ holds a credential that can upload it.
 
 ## Trusted Publishing setup
 
-One-time configuration, already in place for `apple/coreai-torch`. Recorded here
-so it can be audited or rebuilt.
+One-time configuration, per PyPI's
+[Trusted Publishing docs](https://docs.pypi.org/trusted-publishers/). The
+publisher must be bound to workflow `release.yml` **and** environment `pypi` —
+without the environment, any workflow named `release.yml` in the repo can
+publish.
 
-### On PyPI
-
-As an owner of the `coreai-torch` project, under **Manage project → Publishing →
-Add a new publisher → GitHub**:
-
-| Field             | Value                |
-| ----------------- | -------------------- |
-| Owner             | `apple`              |
-| Repository name   | `coreai-torch`       |
-| Workflow name     | `release.yml`        |
-| Environment name  | `pypi`               |
-
-The environment name is not optional here. Without it, *any* workflow in the
-repo named `release.yml` can publish; with it, PyPI additionally requires the
-OIDC token to assert the `pypi` environment, which is where the approval gate
-lives.
-
-For a project that does not exist on PyPI yet, the same form is available as a
-**pending publisher** from your account's Publishing page; the project is
-created on first successful upload.
-
-### On GitHub
-
-Under **Settings → Environments → New environment → `pypi`**:
-
-- **Required reviewers**: the release managers team, with **prevent
-  self-review** enabled — so the person who pushed the tag cannot approve their
-  own release.
-- **Wait timer**: 15 minutes, leaving time to cancel a run started by mistake.
-- **Deployment branches and tags**: restrict to the tag pattern `v*.*.*`, so a
-  run from a branch cannot reach the environment even if the workflow gate is
-  ever loosened.
-
-No secret is added to the environment. The `id-token: write` permission in the
-`publish` job is what lets it mint the OIDC token, and it is scoped to that job
-alone.
+The `pypi` GitHub environment carries the release policy: required reviewers with
+**prevent self-review** (so the tag pusher cannot approve their own release), a
+15-minute wait timer, and deployments restricted to the tag pattern `v*.*.*`. It
+holds no secrets — `id-token: write` on the `publish` job is what mints the OIDC
+token, scoped to that job alone.
 
 ## Other indexes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,12 +12,16 @@ one job, so no long-lived API token is stored in the repo or in an org secret.
    `coreai_torch/__version__.py`, update the docs version metadata, and get the
    PR reviewed and merged.
 2. Tag the merge commit `vMAJOR.MINOR.PATCH` — matching `__version__` exactly —
-   and push the tag:
+   with a signed tag, and push it:
 
    ```bash
-   git tag v0.5.0 <merge-sha>
+   git tag -s v0.5.0 <merge-sha> -m 'coreai-torch 0.5.0'
    git push origin v0.5.0
    ```
+
+   The tag is the trust anchor for the release: the workflow builds, tests, and
+   publishes from it, so signing it is what ties the published artifact to a
+   known signer. Check it shows as `Verified` on GitHub after pushing.
 
 3. Pushing the tag starts the `Release` workflow. `build` verifies the tag
    matches `__version__`, builds the wheel and sdist, and rebuilds a wheel from

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,9 @@ one job, so no long-lived API token is stored in the repo or in an org secret.
    ```
 
 3. Pushing the tag starts the `Release` workflow. `build` verifies the tag
-   matches `__version__` and builds the wheel and sdist; `smoke-test` installs
-   that wheel into a clean venv on each supported Python version and imports the
+   matches `__version__`, builds the wheel and sdist, and rebuilds a wheel from
+   the sdist to confirm the sdist is complete; `smoke-test` installs the built
+   wheel into a clean venv on each supported Python version and imports the
    public API.
 4. `publish` then waits on the `pypi` GitHub environment. A release manager other
    than the tag pusher approves it, and the vetted artifact is uploaded to PyPI.
@@ -77,9 +78,8 @@ No secret is added to the environment. The `id-token: write` permission in the
 `publish` job is what lets it mint the OIDC token, and it is scoped to that job
 alone.
 
-## Internal publishing
+## Other indexes
 
-Trusted Publishing covers PyPI only. Publishing to Apple's internal Artifactory
-index still uses `scripts/release.sh` with `UV_PUBLISH_USERNAME` /
-`UV_PUBLISH_PASSWORD`; pass `--skip-publish` when the PyPI upload is handled by
-the workflow.
+Trusted Publishing covers PyPI only. Publishing to another index still goes
+through `scripts/release.sh` with `UV_PUBLISH_USERNAME` / `UV_PUBLISH_PASSWORD`;
+pass `--skip-publish` when the PyPI upload is handled by the workflow.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ one job, so no long-lived API token is stored in the repo or in an org secret.
 
 1. On a release branch, pin dependencies, bump `__version__` in
    `coreai_torch/__version__.py`, update the docs version metadata, and get the
-   PR reviewed and merged. `/release stage1` walks these checks.
+   PR reviewed and merged.
 2. Tag the merge commit `vMAJOR.MINOR.PATCH` — matching `__version__` exactly —
    and push the tag:
 
@@ -26,7 +26,7 @@ one job, so no long-lived API token is stored in the repo or in an org secret.
    public API.
 4. `publish` then waits on the `pypi` GitHub environment. A release manager other
    than the tag pusher approves it, and the vetted artifact is uploaded to PyPI.
-5. Deploy the docs: `./docs/deploy.sh` and `./docs/deploy.sh --remote pie`.
+5. Deploy the docs: `./docs/deploy.sh`.
 
 To exercise the build and smoke test without publishing, run the workflow
 manually — `gh workflow run release.yml --ref <branch>`. The `publish` job is


### PR DESCRIPTION
  ## Description:
  - Adds `.github/workflows/release.yml`, which publishes to PyPI on a `vX.Y.Z` tag push using Trusted Publishing: https://docs.pypi.org/trusted-publishers/ - a short-lived OIDC token minted for one job