### PR TITLE
Replace graph isomorphism with linear-time graph matching

### DIFF
--- a/coreai_torch/debugging/graph_diff.py
+++ b/coreai_torch/debugging/graph_diff.py
@@ -16,15 +16,24 @@ from __future__ import annotations
 
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from enum import Enum
+from io import StringIO
 from typing import Any, TextIO
 
 import networkx as nx  # type: ignore[import-untyped]
 import torch
 from coreai._compiler.ir import Block, Operation, Region, Value
 from coreai.authoring import AIProgram
-from networkx.algorithms import isomorphism  # type: ignore[import-untyped]
+
+from .graph_match import (
+    Label,
+    WeightPolicy,
+    align,
+    node_labels,
+    responsible_op,
+)
+from .table_writer import _Column, _Row, _TableSpec, _write_table
 
 # ---------------------------------------------------------------------------
 # Regex patterns for composite diffing
@@ -38,10 +47,9 @@ class OpDiffType(Enum):
     """Type of operation difference in structural diff."""
 
     ALIGNED = "aligned"  # Structurally identical
-    MODIFIED = "modified"  # Same name, different structure
+    MODIFIED = "modified"  # Corresponds, but is not identical
     REMOVED = "removed"  # Only in source
     ADDED = "added"  # Only in target
-    POSITION_ONLY = "position_only"  # Same structure, different position (not shown)
 
 
 class _AIProgramGraphBuilder:
@@ -203,6 +211,7 @@ class GraphDiffSummary:
     source_edge_count: int
     target_edge_count: int
     mapped_node_count: int = 0
+    modified_node_count: int = 0
     unmapped_source_node_count: int = 0
     unmapped_target_node_count: int = 0
     unmapped_source_edge_count: int = 0
@@ -212,25 +221,39 @@ class GraphDiffSummary:
 @dataclass
 class GraphDiff:
     """
-    Result of structural graph comparison using isomorphism.
+    Result of structural graph comparison.
 
     Attributes:
-        is_isomorphic: Whether the graphs are structurally identical
-        source_to_target_mapping: Maps node IDs from source graph to target graph
-        target_to_source_mapping: Maps node IDs from target graph to source graph
-        unmapped_source_nodes: Node IDs present only in source graph
-        unmapped_target_nodes: Node IDs present only in target graph
-        unmapped_source_edges: Edges present only in source graph
-        unmapped_target_edges: Edges present only in target graph
+        is_isomorphic: Whether the graphs are provably the same graph. A complete
+            verified correspondence accounting for every edge, not a search result:
+            see `graph_match._is_isomorphism` for what the proof rests on.
+        source_to_target_mapping: Every source node that has a counterpart, mapped
+            to it -- identical and modified alike. `modified_node_pairs` is what
+            separates the two.
+        target_to_source_mapping: The same correspondence, inverted
+        modified_node_pairs: Nodes that correspond but are not identical, as
+            `(source, target)`. The same op, wired or configured differently -- a
+            rewiring, a reshape, a changed attribute. Neither added nor removed,
+            because it is still there and still in the same place in the source.
+        unmapped_source_nodes: Node IDs with no counterpart in the target
+        unmapped_target_nodes: Node IDs with no counterpart in the source
+        unmapped_source_edges: Source edges with no corresponding target edge
+        unmapped_target_edges: Target edges with no corresponding source edge
         summary: Summary statistics
         source_graph: Source NetworkX graph with IR references in nodes
         target_graph: Target NetworkX graph with IR references in nodes
+
+    Lifetime: the two graphs hold `ir_object` references owned by the programs they
+    were built from, and comparison reads them lazily. A `GraphDiff` is therefore
+    only usable while both programs are alive -- dropping an `AIProgram` and keeping
+    its diff segfaults the interpreter, with no Python traceback to say why.
 
     """
 
     is_isomorphic: bool
     source_to_target_mapping: dict[int, int]
     target_to_source_mapping: dict[int, int]
+    modified_node_pairs: list[tuple[int, int]]
     unmapped_source_nodes: list[int]
     unmapped_target_nodes: list[int]
     unmapped_source_edges: list[tuple[int, int]]
@@ -241,108 +264,65 @@ class GraphDiff:
 
 
 # ---------------------------------------------------------------------------
-# Greedy topological matching
+# Edge correspondence
 # ---------------------------------------------------------------------------
 
 
-def _greedy_topological_match(
-    source_graph: nx.DiGraph,
-    target_graph: nx.DiGraph,
-    node_match: Any,
-    edge_match: Any,
-) -> dict[int, int]:
-    """Find partial node mapping using greedy topological matching.
-
-    This is much faster than subgraph_isomorphisms_iter for large graphs,
-    providing O(n) matching instead of exponential worst case.
+def _slot(data: dict[str, Any]) -> tuple[str, int]:
     """
+    Which operand position an edge occupies.
 
-    def get_op_nodes_by_name(graph: nx.DiGraph) -> dict[str, list[int]]:
-        ops_by_name: dict[str, list[int]] = {}
-        try:
-            ordered_nodes = list(nx.topological_sort(graph))
-        except nx.NetworkXUnfeasible:
-            ordered_nodes = sorted(graph.nodes())
-        for n in ordered_nodes:
-            attrs = graph.nodes[n]
-            if attrs.get("type") == "op":
-                op_name = attrs.get("op_name", "unknown")
-                ops_by_name.setdefault(op_name, []).append(n)
-        return ops_by_name
-
-    source_ops = get_op_nodes_by_name(source_graph)
-    target_ops = get_op_nodes_by_name(target_graph)
-
-    mapping: dict[int, int] = {}
-    for op_name in source_ops:
-        if op_name not in target_ops:
-            continue
-        src_ids = source_ops[op_name]
-        tgt_ids = target_ops[op_name]
-        for src_id, tgt_id in zip(src_ids, tgt_ids, strict=False):
-            mapping[src_id] = tgt_id
-
-    _extend_mapping_to_connected_nodes(mapping, source_graph, target_graph)
-    return mapping
+    Normalised the same way `graph_match` normalises it, so a graph flavour that
+    omits either attribute compares equal to `("", 0)` rather than raising.
+    """
+    return (str(data.get("edge_type", "")), int(data.get("index", 0)))
 
 
-def _extend_mapping_to_connected_nodes(
-    mapping: dict[int, int],
-    source_graph: nx.DiGraph,
-    target_graph: nx.DiGraph,
-) -> None:
-    """Extend an op-level mapping to include connected non-op nodes."""
-    mapped_target: set[int] = set(mapping.values())
-    for src_op, tgt_op in list(mapping.items()):
-        _match_neighbors(
-            src_op, tgt_op, source_graph, target_graph, mapping, mapped_target, "out"
-        )
-        _match_neighbors(
-            src_op, tgt_op, source_graph, target_graph, mapping, mapped_target, "in"
-        )
-
-
-def _match_neighbors(
-    src_node: int,
-    tgt_node: int,
+def _unmapped_edges(
     source_graph: nx.DiGraph,
     target_graph: nx.DiGraph,
     mapping: dict[int, int],
-    mapped_target: set[int],
-    direction: str,
-) -> None:
-    """Match neighboring non-op nodes by edge type and index."""
-    if direction == "out":
-        src_edges = list(source_graph.out_edges(src_node, data=True))
-        tgt_edges = list(target_graph.out_edges(tgt_node, data=True))
-    else:
-        src_edges = list(source_graph.in_edges(src_node, data=True))
-        tgt_edges = list(target_graph.in_edges(tgt_node, data=True))
+) -> list[tuple[int, int]]:
+    """
+    Source edges with no counterpart in the target under `mapping`.
 
-    def group_edges(
-        edges: list[tuple[int, int, dict[str, Any]]], direction: str
-    ) -> dict[tuple[str, int], int]:
-        groups: dict[tuple[str, int], int] = {}
-        for u, v, data in edges:
-            key = (data.get("edge_type", ""), data.get("index", 0))
-            neighbor = v if direction == "out" else u
-            groups[key] = neighbor
-        return groups
+    An edge corresponds only if both endpoints map, the mapped pair is an edge on
+    the other side, *and* it occupies the same slot. Checking only that both
+    endpoints were mapped -- which is what this replaced -- counted an edge as
+    common whenever its nodes were, so a pure rewiring reported every edge as
+    common and the "common subgraph" line read 100% for a graph that had been
+    rewired.
 
-    src_groups = group_edges(src_edges, direction)
-    tgt_groups = group_edges(tgt_edges, direction)
+    Called with the full correspondence, modified pairs included: a modified op
+    still exists on the other side, so its untouched operand edges genuinely
+    correspond and only the moved ones do not.
 
-    for key, src_neighbor in src_groups.items():
-        if src_neighbor in mapping:
+    Args:
+        source_graph: The graph whose edges are being classified.
+        target_graph: The graph they are looked for in.
+        mapping: Source node id -> target node id.
+
+    Returns:
+        The source edges with no corresponding target edge.
+
+    """
+    unmapped: list[tuple[int, int]] = []
+    for producer, consumer, data in source_graph.edges(data=True):
+        image_producer = mapping.get(producer)
+        image_consumer = mapping.get(consumer)
+        if image_producer is None or image_consumer is None:
+            unmapped.append((producer, consumer))
             continue
-        tgt_neighbor = tgt_groups.get(key)
-        if tgt_neighbor is None or tgt_neighbor in mapped_target:
+
+        if not target_graph.has_edge(image_producer, image_consumer):
+            unmapped.append((producer, consumer))
             continue
-        src_type = source_graph.nodes[src_neighbor].get("type")
-        tgt_type = target_graph.nodes[tgt_neighbor].get("type")
-        if src_type == tgt_type and src_type != "op":
-            mapping[src_neighbor] = tgt_neighbor
-            mapped_target.add(tgt_neighbor)
+
+        image = target_graph.edges[image_producer, image_consumer]
+        if _slot(image) != _slot(data):
+            unmapped.append((producer, consumer))
+
+    return unmapped
 
 
 # ---------------------------------------------------------------------------
@@ -353,120 +333,68 @@ def _match_neighbors(
 def compute_graph_diff(
     source_graph: nx.DiGraph,
     target_graph: nx.DiGraph,
+    *,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
 ) -> GraphDiff:
     """
-    Compute structural differences using graph isomorphism.
+    Compute structural differences between two graphs.
 
-    Uses NetworkX's DiGraphMatcher to find structural correspondence
-    between graphs and identify differences. For non-isomorphic graphs,
-    uses a fast greedy topological matching instead of exponential
-    subgraph isomorphism enumeration.
+    Which node became which comes from `graph_match.align`, which labels each node
+    with what makes it that op, fingerprints bottom-up, anchors on those hashes,
+    propagates along dataflow and verifies every pair. Linear, and no search.
 
     Args:
         source_graph: Source (reference/expected) graph
         target_graph: Target (actual/test) graph
+        weights: Whether parameter *values* count towards a node's identity. Off by
+            default: converting a model twice re-initialises its parameters, so
+            comparing values reports every diff as a total rewrite. Shapes and
+            dtypes are compared either way.
 
     Returns:
-        GraphDiff object containing isomorphism-based structural comparison
+        GraphDiff object describing the correspondence and what it leaves over
 
     """
+    alignment = align(source_graph, target_graph, weights=weights)
 
-    # Define matching functions for isomorphism
-    def node_match(n1: dict[str, Any], n2: dict[str, Any]) -> bool:
-        """Check if two nodes match structurally."""
-        return n1.get("type") == n2.get("type") and n1.get("op_name") == n2.get(
-            "op_name",
-        )
+    # Every source node with a counterpart, identical or not. Modified pairs belong
+    # here: composite bodies are paired by walking this mapping, so leaving a
+    # rewired `coreai.invoke` out of it would leave its callee never paired and
+    # never reported. `modified_node_pairs` is what tells the two apart.
+    source_to_target = {**alignment.mapping, **dict(alignment.modified)}
+    target_to_source = {v: k for k, v in source_to_target.items()}
 
-    def edge_match(e1: dict[str, Any], e2: dict[str, Any]) -> bool:
-        """Check if two edges match structurally."""
-        return e1.get("edge_type") == e2.get("edge_type")
-
-    # Create matcher for directed graphs
-    matcher = isomorphism.DiGraphMatcher(
-        source_graph,
-        target_graph,
-        node_match=node_match,
-        edge_match=edge_match,
+    unmapped_source_edges = _unmapped_edges(
+        source_graph, target_graph, source_to_target
     )
-
-    is_isomorphic = matcher.is_isomorphic()
-
-    # Get node mapping if isomorphic
-    if is_isomorphic:
-        source_to_target = matcher.mapping
-        target_to_source = {v: k for k, v in source_to_target.items()}
-
-        summary = GraphDiffSummary(
-            source_node_count=source_graph.number_of_nodes(),
-            target_node_count=target_graph.number_of_nodes(),
-            source_edge_count=source_graph.number_of_edges(),
-            target_edge_count=target_graph.number_of_edges(),
-            mapped_node_count=len(source_to_target),
-            unmapped_source_node_count=0,
-            unmapped_target_node_count=0,
-            unmapped_source_edge_count=0,
-            unmapped_target_edge_count=0,
-        )
-
-        return GraphDiff(
-            is_isomorphic=True,
-            source_to_target_mapping=source_to_target,
-            target_to_source_mapping=target_to_source,
-            unmapped_source_nodes=[],
-            unmapped_target_nodes=[],
-            unmapped_source_edges=[],
-            unmapped_target_edges=[],
-            summary=summary,
-            source_graph=source_graph,
-            target_graph=target_graph,
-        )
-
-    # Not fully isomorphic — use greedy topological matching (fast)
-    best_mapping = _greedy_topological_match(
-        source_graph, target_graph, node_match, edge_match
+    unmapped_target_edges = _unmapped_edges(
+        target_graph, source_graph, target_to_source
     )
-
-    # Identify unmapped nodes and edges
-    mapped_source = set(best_mapping.keys())
-    mapped_target = set(best_mapping.values())
-
-    unmapped_source_nodes = [n for n in source_graph.nodes() if n not in mapped_source]
-    unmapped_target_nodes = [n for n in target_graph.nodes() if n not in mapped_target]
-
-    # Identify unmapped edges
-    def edge_is_mapped(edge: tuple[int, int], mapping: dict[int, int]) -> bool:
-        """Check if an edge is fully mapped."""
-        src, dst = edge
-        return src in mapping and dst in mapping
-
-    unmapped_source_edges = [
-        e for e in source_graph.edges() if not edge_is_mapped(e, best_mapping)
-    ]
-    unmapped_target_edges = [
-        e
-        for e in target_graph.edges()
-        if not edge_is_mapped(e, {v: k for k, v in best_mapping.items()})
-    ]
 
     summary = GraphDiffSummary(
         source_node_count=source_graph.number_of_nodes(),
         target_node_count=target_graph.number_of_nodes(),
         source_edge_count=source_graph.number_of_edges(),
         target_edge_count=target_graph.number_of_edges(),
-        mapped_node_count=len(best_mapping),
-        unmapped_source_node_count=len(unmapped_source_nodes),
-        unmapped_target_node_count=len(unmapped_target_nodes),
+        # Identically matched only, so that mapped + modified + unmapped adds up to
+        # the source node count and "common subgraph" does not count a rewired op as
+        # common. It is therefore smaller than `len(source_to_target_mapping)`
+        # whenever anything is modified.
+        mapped_node_count=len(alignment.mapping),
+        modified_node_count=len(alignment.modified),
+        unmapped_source_node_count=len(alignment.removed),
+        unmapped_target_node_count=len(alignment.added),
         unmapped_source_edge_count=len(unmapped_source_edges),
         unmapped_target_edge_count=len(unmapped_target_edges),
     )
 
     return GraphDiff(
-        is_isomorphic=False,
-        source_to_target_mapping=best_mapping,
-        target_to_source_mapping={v: k for k, v in best_mapping.items()},
-        unmapped_source_nodes=unmapped_source_nodes,
-        unmapped_target_nodes=unmapped_target_nodes,
+        is_isomorphic=alignment.identical,
+        source_to_target_mapping=source_to_target,
+        target_to_source_mapping=target_to_source,
+        modified_node_pairs=alignment.modified,
+        unmapped_source_nodes=alignment.removed,
+        unmapped_target_nodes=alignment.added,
         unmapped_source_edges=unmapped_source_edges,
         unmapped_target_edges=unmapped_target_edges,
         summary=summary,
@@ -630,188 +558,93 @@ def _format_summary(diff: GraphDiff) -> list[tuple[int, str]]:
     return lines
 
 
-def _count_edges_by_type(
-    graph: nx.DiGraph,
-    node_id: int,
-    edge_type: str,
-    direction: str = "out",
-) -> int:
-    """Count edges of a specific type for a node."""
-    edges = graph.out_edges(node_id) if direction == "out" else graph.in_edges(node_id)
-    return sum(1 for e in edges if graph[e[0]][e[1]].get("edge_type") == edge_type)
+def _incoming(graph: nx.DiGraph, node_id: int) -> set[tuple[str, int, int]]:
+    """This node's incoming edges as `(edge_type, index, producer)`."""
+    return {
+        (*_slot(data), producer)
+        for producer, _, data in graph.in_edges(node_id, data=True)
+    }
 
 
-def _compute_aiprogram_op_diff_details(
+def _describe_modification(
     src_id: int,
     tgt_id: int,
-    source_graph: nx.DiGraph,
-    target_graph: nx.DiGraph,
-) -> tuple[OpDiffType, str]:
-    """Compute diff details for AIProgram operations."""
-    # Count key structural elements
-    src_operands = _count_edges_by_type(source_graph, src_id, "operand", "in")
-    tgt_operands = _count_edges_by_type(target_graph, tgt_id, "operand", "in")
-    src_results = _count_edges_by_type(source_graph, src_id, "defines", "out")
-    tgt_results = _count_edges_by_type(target_graph, tgt_id, "defines", "out")
-    src_regions = _count_edges_by_type(source_graph, src_id, "contains_region", "out")
-    tgt_regions = _count_edges_by_type(target_graph, tgt_id, "contains_region", "out")
-
-    # Build details string
-    details_parts = []
-    if src_operands != tgt_operands:
-        details_parts.append(f"operands:{src_operands}\u2192{tgt_operands}")
-    if src_results != tgt_results:
-        details_parts.append(f"results:{src_results}\u2192{tgt_results}")
-    if src_regions != tgt_regions:
-        details_parts.append(f"regions:{src_regions}\u2192{tgt_regions}")
-
-    if details_parts:
-        return (OpDiffType.MODIFIED, ", ".join(details_parts))
-    return (OpDiffType.POSITION_ONLY, "")
-
-
-def _compute_torch_op_diff_details(
-    src_id: int,
-    tgt_id: int,
-    source_graph: nx.DiGraph,
-    target_graph: nx.DiGraph,
-) -> tuple[OpDiffType, str]:
-    """Compute diff details for torch.fx.Node operations."""
-    # Count data flow edges (inputs/outputs)
-    src_inputs = _count_edges_by_type(source_graph, src_id, "data_flow", "in")
-    tgt_inputs = _count_edges_by_type(target_graph, tgt_id, "data_flow", "in")
-    src_outputs = _count_edges_by_type(source_graph, src_id, "data_flow", "out")
-    tgt_outputs = _count_edges_by_type(target_graph, tgt_id, "data_flow", "out")
-
-    # Build details string
-    details_parts = []
-    if src_inputs != tgt_inputs:
-        details_parts.append(f"inputs:{src_inputs}\u2192{tgt_inputs}")
-    if src_outputs != tgt_outputs:
-        details_parts.append(f"outputs:{src_outputs}\u2192{tgt_outputs}")
-
-    if details_parts:
-        return (OpDiffType.MODIFIED, ", ".join(details_parts))
-    return (OpDiffType.POSITION_ONLY, "")
-
-
-def _compute_op_diff_details(
-    src_id: int,
-    tgt_id: int,
-    source_graph: nx.DiGraph,
-    target_graph: nx.DiGraph,
-) -> tuple[OpDiffType, str]:
+    labels: tuple[dict[int, Label], dict[int, Label]],
+    graphs: tuple[nx.DiGraph, nx.DiGraph],
+    mapping: dict[int, int],
+) -> str:
     """
-    Compute detailed description of what changed between two operations.
+    Why a corresponding pair is not identical, in the terms the comparison used.
 
-    Dispatches to either AIProgram or torch-specific diff computation.
+    Reports the first label field that differs, or the operand slots whose producer
+    moved -- which is exactly what verification rejected the pair on. This replaces
+    counting operand/result/region edges per graph flavour and reporting the deltas:
+    those counts are equal for a rewiring, which is the case most worth naming.
+
+    Args:
+        src_id: Source node of the pair.
+        tgt_id: Target node of the pair.
+        labels: Node labels for `(source, target)`, computed once by the caller.
+        graphs: The `(source, target)` graphs.
+        mapping: The full source-to-target correspondence.
 
     Returns:
-        Tuple of (diff_type, details_string)
+        A short description, empty if nothing can be pinned down.
 
     """
-    # Detect graph type by checking node attributes
-    src_node = source_graph.nodes[src_id]
-    is_torch_graph = "torch_object" in src_node
+    source_labels, target_labels = labels
+    source_graph, target_graph = graphs
 
-    if is_torch_graph:
-        return _compute_torch_op_diff_details(
-            src_id,
-            tgt_id,
-            source_graph,
-            target_graph,
-        )
-    return _compute_aiprogram_op_diff_details(
-        src_id, tgt_id, source_graph, target_graph
+    source_label = source_labels.get(src_id, Label())
+    target_label = target_labels.get(tgt_id, Label())
+    if source_label != target_label:
+        for field in fields(Label):
+            before = getattr(source_label, field.name)
+            after = getattr(target_label, field.name)
+            if before != after:
+                return f"{field.name}: {before or '-'}\u2192{after or '-'}"
+
+        return "label differs"
+
+    target_incoming = _incoming(target_graph, tgt_id)
+    moved = sorted(
+        index
+        for edge_type, index, producer in _incoming(source_graph, src_id)
+        if (edge_type, index, mapping.get(producer, -1)) not in target_incoming
     )
+    if moved:
+        return "rewired: " + ", ".join(f"operand {index}" for index in moved)
+
+    # Nothing else is left. Verification rejected this pair, and it rejects only on
+    # a label mismatch or an operand mismatch; the labels here are the ones with
+    # parameter values *left out*, and the operands correspond. So the values are
+    # what differ -- which is only reachable when the diff was computed under
+    # `WeightPolicy.DIGEST`, since that is the only policy that looks at them.
+    return "parameter values differ"
 
 
-def _group_ops_by_name(nodes: list[int], graph: nx.DiGraph) -> dict[str, list[int]]:
-    """Group operation nodes by their operation name."""
-    ops_by_name: dict[str, list[int]] = {}
-    for n in nodes:
-        if graph.nodes[n].get("type") == "op":
-            op_name = graph.nodes[n].get("op_name", "unknown")
-            ops_by_name.setdefault(op_name, []).append(n)
-    return ops_by_name
-
-
-def _add_aligned_ops(
-    diff: GraphDiff,
+def _is_one_op_changed(
     source_graph: nx.DiGraph,
     target_graph: nx.DiGraph,
-    rows: list[tuple[str, str, str, str, str, str]],
-) -> None:
-    """Add structurally aligned operations to rows."""
-    for src_id, tgt_id in sorted(diff.source_to_target_mapping.items()):
-        if source_graph.nodes[src_id].get("type") == "op":
-            src_op = source_graph.nodes[src_id].get("op_name", "unknown")
-            tgt_op = target_graph.nodes[tgt_id].get("op_name", "unknown")
-            rows.append(
-                (
-                    str(src_id),
-                    str(tgt_id),
-                    OpDiffType.ALIGNED.value,
-                    src_op,
-                    tgt_op,
-                    "",
-                ),
-            )
+    src_id: int,
+    tgt_id: int,
+) -> bool:
+    """
+    Whether a corresponding pair is one op that changed, rather than two ops.
 
+    `modified` means *the same operation*, wired or configured differently. A pair
+    whose operations do not even share a name is not that: it is one op gone and
+    another arrived, and reporting it as a modification hides what used to be there.
 
-def _add_matched_by_name_ops(
-    source_ids: list[int],
-    target_ids: list[int],
-    op_name: str,
-    graphs: tuple[nx.DiGraph, nx.DiGraph],
-    output: tuple[list[tuple[str, str, str, str, str, str]], set[int]],
-) -> None:
-    """Add operations matched by name to rows."""
-    source_graph, target_graph = graphs
-    rows, matched = output
-
-    # Pair up operations
-    for src_id, tgt_id in zip(source_ids, target_ids, strict=False):
-        diff_type, details = _compute_op_diff_details(
-            src_id,
-            tgt_id,
-            source_graph,
-            target_graph,
-        )
-        if diff_type != OpDiffType.POSITION_ONLY:
-            rows.append(
-                (str(src_id), str(tgt_id), diff_type.value, op_name, op_name, details),
-            )
-        matched.update([src_id, tgt_id])
-
-    # Handle count mismatches
-    count_diff = len(source_ids) - len(target_ids)
-    if count_diff > 0:
-        rows.extend(
-            (
-                str(src_id),
-                "-",
-                OpDiffType.REMOVED.value,
-                op_name,
-                "",
-                f"{count_diff} extra in source",
-            )
-            for src_id in source_ids[len(target_ids) :]
-        )
-        matched.update(source_ids[len(target_ids) :])
-    elif count_diff < 0:
-        rows.extend(
-            (
-                "-",
-                str(tgt_id),
-                OpDiffType.ADDED.value,
-                "",
-                op_name,
-                f"{-count_diff} extra in target",
-            )
-            for tgt_id in target_ids[len(source_ids) :]
-        )
-        matched.update(target_ids[len(source_ids) :])
+    The distinction matters because a difference often lands on a **value** node --
+    `relu`'s result pairs with `sigmoid`'s, since they have the same type and the same
+    consumer -- and resolving that pair to the operations behind it would otherwise
+    collapse a removal and an addition into "sigmoid was modified", with no mention of
+    the relu.
+    """
+    return source_graph.nodes[src_id].get("op_name") == target_graph.nodes[tgt_id].get(
+        "op_name"
+    )
 
 
 def _format_unified_ops_table(
@@ -819,94 +652,122 @@ def _format_unified_ops_table(
     source_graph: nx.DiGraph,
     target_graph: nx.DiGraph,
     max_items: int | None = None,
-) -> list[tuple[int, str]]:
-    """Format unified operations table with ANSI coloring for removed/added ops."""
-    lines: list[tuple[int, str]] = []
-    lines.append((0, "Operations Diff Table:"))
+) -> _TableSpec | None:
+    """
+    Build the unified operations table, styling removed/added ops.
 
+    Args:
+        diff: GraphDiff result to render.
+        source_graph: Source (reference) graph.
+        target_graph: Target (actual) graph.
+        max_items: Maximum number of rows to include, or None for all.
+
+    Returns:
+        The table, or None when there are no differing operations to show.
+
+    """
     rows: list[tuple[str, str, str, str, str, str]] = []
 
-    # Group unmapped ops by name
-    source_ops_by_name = _group_ops_by_name(diff.unmapped_source_nodes, source_graph)
-    target_ops_by_name = _group_ops_by_name(diff.unmapped_target_nodes, target_graph)
+    # A modification is one fact about one pair of ops, so it claims both sides:
+    # an op that still exists but computes something different is *modified*, and
+    # listing it as removed or added as well would say two contradictory things
+    # about one op.
+    claimed_source: set[int] = set()
+    claimed_target: set[int] = set()
+    labels = (node_labels(source_graph), node_labels(target_graph))
 
-    # Match and add operations by name
-    matched_by_name: set[int] = set()
-    common_names = set(source_ops_by_name.keys()) & set(target_ops_by_name.keys())
+    for src_node, tgt_node in diff.modified_node_pairs:
+        src_id = responsible_op(source_graph, src_node)
+        tgt_id = responsible_op(target_graph, tgt_node)
+        if src_id is None or tgt_id is None:
+            continue
+        if src_id in claimed_source or tgt_id in claimed_target:
+            continue
+        if not _is_one_op_changed(source_graph, target_graph, src_id, tgt_id):
+            # Two different ops. Leave them to the removed and added passes, which
+            # will name both.
+            continue
 
-    for op_name in sorted(common_names):
-        _add_matched_by_name_ops(
-            source_ops_by_name[op_name],
-            target_ops_by_name[op_name],
-            op_name,
-            (source_graph, target_graph),
-            (rows, matched_by_name),
+        claimed_source.add(src_id)
+        claimed_target.add(tgt_id)
+        rows.append(
+            (
+                str(src_id),
+                str(tgt_id),
+                OpDiffType.MODIFIED.value,
+                source_graph.nodes[src_id].get("op_name", "unknown"),
+                target_graph.nodes[tgt_id].get("op_name", "unknown"),
+                _describe_modification(
+                    src_node,
+                    tgt_node,
+                    labels,
+                    (source_graph, target_graph),
+                    diff.source_to_target_mapping,
+                ),
+            )
         )
 
-    # Add unique operations (no name match)
-    for op_name, src_ids in source_ops_by_name.items():
-        if op_name not in common_names:
-            rows.extend(
+    for nodes, graph, claimed, removed in (
+        (diff.unmapped_source_nodes, source_graph, claimed_source, True),
+        (diff.unmapped_target_nodes, target_graph, claimed_target, False),
+    ):
+        for node in nodes:
+            op_id = responsible_op(graph, node)
+            if op_id is None or op_id in claimed:
+                continue
+
+            claimed.add(op_id)
+            op_name = graph.nodes[op_id].get("op_name", "unknown")
+            rows.append(
                 (
-                    str(src_id),
+                    str(op_id),
                     "-",
                     OpDiffType.REMOVED.value,
                     op_name,
                     "",
                     "no match in target",
                 )
-                for src_id in src_ids
-            )
-
-    for op_name, tgt_ids in target_ops_by_name.items():
-        if op_name not in common_names:
-            rows.extend(
-                (
+                if removed
+                else (
                     "-",
-                    str(tgt_id),
+                    str(op_id),
                     OpDiffType.ADDED.value,
                     "",
                     op_name,
                     "no match in source",
                 )
-                for tgt_id in tgt_ids
             )
 
     if not rows:
-        return lines
+        return None
 
-    # Dynamic column widths
-    headers = ("src_id", "tgt_id", "status", "src_op", "tgt_op", "details")
     items_to_show = rows if max_items is None else rows[:max_items]
-    col_widths = list(len(h) for h in headers)
+    caption = None
+    if max_items is not None and len(rows) > max_items:
+        caption = f"... and {len(rows) - max_items} more operations"
+
+    spec = _TableSpec(
+        title="Operations Diff Table:",
+        columns=(
+            _Column("src_id", justify="right"),
+            _Column("tgt_id", justify="right"),
+            _Column("status"),
+            _Column("src_op"),
+            _Column("tgt_op"),
+            _Column("details"),
+        ),
+        caption=caption,
+    )
     for row in items_to_show:
-        for i, val in enumerate(row):
-            col_widths[i] = max(col_widths[i], len(val))
-
-    fmt = "  ".join(f"{{:<{w}}}" for w in col_widths)
-    sep = "  ".join("\u2500" * w for w in col_widths)
-
-    # ANSI color codes for terminal output
-    RED_BG = "\033[48;2;50;10;10m\033[97m"
-    GREEN_BG = "\033[48;2;10;40;10m\033[97m"
-    RESET = "\033[0m"
-
-    lines.append((1, fmt.format(*headers)))
-    lines.append((1, sep))
-
-    for row in items_to_show:
-        line = fmt.format(*row)
         status = row[2]
         if status == OpDiffType.REMOVED.value:
-            line = f"{RED_BG}{line}{RESET}"
+            style = "white on rgb(50,10,10)"
         elif status == OpDiffType.ADDED.value:
-            line = f"{GREEN_BG}{line}{RESET}"
-        lines.append((1, line))
-
-    if max_items is not None and len(rows) > max_items:
-        lines.append((1, f"... and {len(rows) - max_items} more operations"))
-
-    return lines
+            style = "white on rgb(10,40,10)"
+        else:
+            style = ""
+        spec.add(_Row(cells=row, style=style))
+    return spec
 
 
 def _apply_indentation(lines: list[tuple[int, str]], indent_size: int = 2) -> list[str]:
@@ -960,20 +821,18 @@ def write_diff(
     lines.extend(_format_summary(diff))
     lines.append((0, ""))
 
+    # Write everything above the operations table, then the table itself.
+    for line in _apply_indentation(lines, indent_size):
+        output.write(line + "\n")
+
     # Unified operations table (shows aligned, removed, and added ops)
     table_limit = None if max_items is None else max_items * 2
     ops_table = _format_unified_ops_table(diff, source_graph, target_graph, table_limit)
-    if ops_table:
-        lines.extend(ops_table)
-        lines.append((0, ""))
+    if ops_table is not None:
+        _write_table(ops_table, output)
+        output.write("\n")
 
-    # Footer
-    lines.append((0, "=" * 80))
-
-    # Apply indentation and write to output
-    formatted_lines = _apply_indentation(lines, indent_size)
-    for line in formatted_lines:
-        output.write(line + "\n")
+    output.write("=" * 80 + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -986,6 +845,7 @@ def compute_coreai_program_diff(
     target_program: AIProgram,
     *,
     entry_point: str | None = "main",
+    weights: WeightPolicy = WeightPolicy.IGNORE,
 ) -> GraphDiff:
     """
     Compute structural diff between two AIPrograms.
@@ -998,6 +858,19 @@ def compute_coreai_program_diff(
         target_program: Target (actual/test) AIProgram
         entry_point: Name of the entry point function to compare.
             Use None to compare all graphs in the module.
+        weights: Whether parameter *values* count towards a node's identity, so
+            that two builds differing only in their weights are reported as
+            modified rather than as identical. Off by default: converting a model
+            twice re-initialises its parameters, so comparing values would report
+            every layer as changed. Shapes and dtypes are compared either way.
+
+            Only meaningful when **this process** produced both programs. A
+            resource-backed parameter is compared by its blob name, which is
+            serialised into a `.aimodel` and not recomputed on load, so two assets
+            written by two runs carry different names for identical weights and
+            `DIGEST` reports them as modified. Nothing here can detect that; a
+            caller that loads assets from disk must not offer this option. See
+            `graph_match._weight_label`.
 
     Returns:
         GraphDiff object with source_graph and target_graph included
@@ -1008,7 +881,7 @@ def compute_coreai_program_diff(
     """
     source_graph = _build_module_graph(source_program._mlir_module, entry_point)
     target_graph = _build_module_graph(target_program._mlir_module, entry_point)
-    return compute_graph_diff(source_graph, target_graph)
+    return compute_graph_diff(source_graph, target_graph, weights=weights)
 
 
 # ---------------------------------------------------------------------------
@@ -1048,6 +921,7 @@ def _diff_matched_composites(
     target_eps: dict[str, Any],
     source_module: Any,
     target_module: Any,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
 ) -> list[tuple[str, GraphDiff | None]]:
     """Diff each matched composite pair and return labeled results."""
     results: list[tuple[str, GraphDiff | None]] = []
@@ -1056,7 +930,7 @@ def _diff_matched_composites(
             continue
         src_graph = _build_module_graph(source_module, src_callee)
         tgt_graph = _build_module_graph(target_module, tgt_callee)
-        diff = compute_graph_diff(src_graph, tgt_graph)
+        diff = compute_graph_diff(src_graph, tgt_graph, weights=weights)
         label = _strip_uuid_suffix(src_callee)
         results.append(
             (f"{label} (source: @{src_callee}, target: @{tgt_callee})", diff)
@@ -1098,6 +972,7 @@ def _report_orphan_composites(
     matched_tgt_callees: set[str],
     source_module: Any,
     target_module: Any,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
 ) -> list[tuple[str, GraphDiff | None]]:
     """Report composites not referenced by any invoke in main."""
     results: list[tuple[str, GraphDiff | None]] = []
@@ -1111,7 +986,7 @@ def _report_orphan_composites(
                 results.append(
                     (
                         f"{label} (unreferenced, @{sym_name})",
-                        compute_graph_diff(src_graph, tgt_graph),
+                        compute_graph_diff(src_graph, tgt_graph, weights=weights),
                     )
                 )
             else:
@@ -1132,6 +1007,8 @@ def _report_orphan_composites(
 def compute_per_graph_diff(
     source_program: AIProgram,
     target_program: AIProgram,
+    *,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
 ) -> list[tuple[str, GraphDiff | None]]:
     """Compute per-graph diffs, matching composites via invoke call sites.
 
@@ -1142,6 +1019,9 @@ def compute_per_graph_diff(
     Args:
         source_program: Source (reference/expected) AIProgram
         target_program: Target (actual/test) AIProgram
+        weights: Whether parameter *values* count towards a node's identity; see
+            `compute_coreai_program_diff`. Under `DIGEST` each graph reaches its own
+            module's parameters, which costs a print of it per graph compared.
 
     Returns:
         List of (label, GraphDiff | None) tuples for each graph in the programs
@@ -1149,17 +1029,20 @@ def compute_per_graph_diff(
     """
     source_eps = _collect_entry_points(source_program._mlir_module)
     target_eps = _collect_entry_points(target_program._mlir_module)
-
     # Fallback when no main graph exists
     if "main" not in source_eps or "main" not in target_eps:
         source_graph = _build_module_graph(source_program._mlir_module)
         target_graph = _build_module_graph(target_program._mlir_module)
-        return [("all", compute_graph_diff(source_graph, target_graph))]
+        return [
+            ("all", compute_graph_diff(source_graph, target_graph, weights=weights))
+        ]
 
     # Diff main graphs
     source_main_graph = _build_module_graph(source_program._mlir_module, "main")
     target_main_graph = _build_module_graph(target_program._mlir_module, "main")
-    main_diff = compute_graph_diff(source_main_graph, target_main_graph)
+    main_diff = compute_graph_diff(
+        source_main_graph, target_main_graph, weights=weights
+    )
 
     results: list[tuple[str, GraphDiff | None]] = [("main", main_diff)]
 
@@ -1177,6 +1060,7 @@ def compute_per_graph_diff(
             target_eps,
             source_program._mlir_module,
             target_program._mlir_module,
+            weights,
         )
     )
 
@@ -1200,6 +1084,7 @@ def compute_per_graph_diff(
             matched_tgt_callees,
             source_program._mlir_module,
             target_program._mlir_module,
+            weights,
         )
     )
 
@@ -1233,6 +1118,7 @@ def format_multi_graph_diff(
         lines.append((0, "=" * 80))
         lines.append((0, ""))
 
+        ops_table: _TableSpec | None = None
         if diff is None:
             lines.append((0, "(no counterpart in the other program)"))
             all_isomorphic = False
@@ -1247,12 +1133,16 @@ def format_multi_graph_diff(
             ops_table = _format_unified_ops_table(
                 diff, diff.source_graph, diff.target_graph, table_limit
             )
-            if ops_table:
-                lines.extend(ops_table)
-                lines.append((0, ""))
 
         formatted = _apply_indentation(lines, indent_size)
-        sections.append("\n".join(formatted))
+        section = "\n".join(formatted)
+        if ops_table is not None:
+            # Render the table into a buffer so it can be embedded in the
+            # returned string alongside the prose sections.
+            buffer = StringIO()
+            _write_table(ops_table, buffer)
+            section = f"{section}\n{buffer.getvalue()}"
+        sections.append(section)
 
     # Overall verdict
     overall: list[tuple[int, str]] = []

--- a/coreai_torch/debugging/graph_match.py
+++ b/coreai_torch/debugging/graph_match.py
@@ -1,0 +1,1345 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Aligning two program graphs, to report what changed.
+
+Answers "which node became which", not "are these isomorphic" -- the diff is built
+from the mapping, and a yes/no verdict says nothing about what differs. Linear time,
+no search.
+
+Five steps:
+
+1. **Label** each node by what makes it that node, each edge by `(edge_type, index)`.
+   The index matters because operand order is semantic: without it `sub(a, b)` and
+   `sub(b, a)` look alike. Parameter payloads and symbol uniquifiers are excluded --
+   they differ between two conversions of one unchanged model.
+2. **Fingerprint** bottom-up over a node's label plus its operands' hashes, so equal
+   hashes mean "computes the same thing from the same inputs". Labels alone cannot:
+   every `add` in a model shares a label.
+3. **Anchor** equal fingerprints, then **propagate** along dataflow slot by slot, so
+   an edit costs what the edit is worth rather than the whole cone below it.
+4. **Assign** the leftovers by shared neighbours, ignoring position -- the only pass
+   that survives a move. See `_assign_residual`.
+5. **Verify** every pair against the full label. Steps 2-4 are heuristics; this is
+   what makes `identical` a proof. A failed pair is `modified`, not removed-plus-added,
+   which would discard the identity and source line of an op that is still there.
+
+Pairs are proposed on `structural_labels` (no result types, no payloads) and verified
+against `node_labels`, so an op whose shape changed still pairs and reads as modified.
+
+**Lifetime.** Labels read `ir_object` lazily at `align` time, so a graph is only usable
+while its program is alive; dropping the `AIProgram` segfaults the interpreter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from collections import Counter, defaultdict, deque
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import networkx as nx  # type: ignore[import-untyped]
+
+try:  # `scipy` is a declared dependency; the fallback is for a trimmed install.
+    import numpy as _numpy
+    from scipy.optimize import linear_sum_assignment as _linear_sum_assignment
+except ImportError:  # pragma: no cover
+    _numpy = None  # type: ignore[assignment]
+    _linear_sum_assignment = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+class WeightPolicy(str, Enum):
+    """
+    Whether a parameter's *values* are part of an op's identity.
+
+    Shapes and dtypes are compared under every policy, so a resized layer is always
+    visible; this is only about the numbers.
+
+    `IGNORE` is the default because a rebuild re-initialises parameters, so comparing
+    values would report every weight of an unchanged model as changed.
+
+    `DIGEST` compares them, near-free: an inline payload is hashed from its buffer, a
+    resource-backed one by its blob name, which is a content hash the compiler already
+    computed. Valid only when one process produced both programs -- that name is
+    seeded per execution and is serialised into a `.aimodel` (see `_weight_label`).
+
+    `DIGEST_PORTABLE` hashes the blob bytes here instead, which is what makes two
+    saved assets comparable, and pays a full print of each module for it (see
+    `resource_digests`).
+    """
+
+    IGNORE = "ignore"  # Compare shape and dtype; ignore the values.
+    DIGEST = "digest"  # Hash the values; trust the compiler's name for blobs.
+    DIGEST_PORTABLE = "digest_portable"  # Hash blob bytes too; works across runs.
+
+
+# `f32`, `f16`, `bf16`. Matched on the element type's name rather than through
+# `ir.FloatType`, to keep this module free of a dependency on the bindings: it is a
+# pure function of two `nx.DiGraph`s, and its tests build graphs by hand.
+_FLOAT_ELEMENT_TYPE = re.compile(r"^(bf|f)\d+$")
+
+# A symbol's *trailing* uniquifier, regenerated on every conversion:
+# `@layer_norm_tzcnrgwt` and `@layer_norm_zovsaktp` name the same composite. Left in,
+# every `coreai.invoke` reads as changed on every rebuild. The alphabet is `a-z0-9`, not
+# the hex `_UUID_SUFFIX_RE` assumes when stripping these for display.
+#
+# The name part is greedy and the suffix must end the symbol: non-greedy, it ate the
+# first long `_word` instead of the last, stripping part of the name and leaving the
+# actual hash in place.
+_SYMBOL_SUFFIX = re.compile(r"@([A-Za-z_][\w$.]*)_[a-z0-9]{8,}(?![\w$.])")
+_SYMBOL_KEPT = r"@\1_"
+
+# `dense_resource<resource_15196384634295780515>`. The name is the compiler's own
+# hash of the payload's bytes, which is what lets it stand in for one -- see
+# `_weight_label`.
+_RESOURCE_REF = re.compile(r"dense_resource<([^>]+)>")
+
+# A blob in a module's printed trailer: `resource_155104…: "0x1000…"`.
+_RESOURCE_BLOB = re.compile(r'([A-Za-z_][\w.]*)\s*:\s*"0x([0-9A-Fa-f]+)"')
+
+# A value's *display* name, which is not part of what an op computes.
+#
+# `coreai.graph` carries `coreai.name = "add_1"` from the traced node, and that name
+# shifts whenever anything upstream changes. Left in, the entry-point op fails to pair
+# and takes its region, block and block arguments with it, each identified by its parent.
+_DISPLAY_NAME = re.compile(r'coreai\.name = "[^"]*"')
+_DISPLAY_NAME_KEPT = "coreai.name"
+
+# A graph's own symbol name is left out of its identity: it names a *place*, and which
+# graph is compared with which is already decided before a pair reaches here, composites
+# pairing through their invoke call sites. Nothing is lost -- the declared name is in
+# `composite_decl` and an invoke's callee is a reference.
+_UNSTABLE_ATTRS = frozenset({"sym_name"})
+
+# A node that has no label: it belongs to neither graph, or was never labelled.
+# Distinct from every real label, since every real node has at least a kind.
+_MISSING = "?"
+_UNMAPPED = None
+
+
+@dataclass(frozen=True)
+class Alignment:
+    """
+    Which node became which, and what that leaves over.
+
+    Attributes:
+        mapping: Verified source id -> target id, for nodes that correspond exactly.
+        removed: Source ids with no counterpart.
+        added: Target ids with no counterpart.
+        modified: Source ids whose counterpart is the same op wired or configured
+            differently, as `(source id, target id)`.
+        identical: Whether the two graphs are provably the same graph.
+
+    """
+
+    mapping: dict[int, int] = field(default_factory=dict)
+    removed: list[int] = field(default_factory=list)
+    added: list[int] = field(default_factory=list)
+    modified: list[tuple[int, int]] = field(default_factory=list)
+    identical: bool = False
+
+    @property
+    def changed(self) -> bool:
+        """Whether anything at all differs."""
+        return bool(self.removed or self.added or self.modified)
+
+
+def _is_parameter(value: Any) -> Any | None:
+    """
+    The shaped type of a payload that is a parameter, or `None` if it is not one.
+
+    A parameter is a non-splat, floating-point tensor of more than one element -- what a
+    rebuild re-initialises, so comparing such payloads by value reports every weight of
+    an untouched model as changed.
+
+    Everything else is compared by value, integers included: shapes, permutations, axes
+    and gather indices are not re-initialised, and size is no safe proxy, since eliding
+    a large integer payload would hide a real change to a gather index. A **quantised**
+    weight is therefore compared by value too -- nothing distinguishes an `si4` weight
+    from a large gather index, and a retrained 4-bit model genuinely has changed.
+    Comparing two saved assets of one then needs `DIGEST_PORTABLE`, a resource handle
+    being seeded per process. See `_resource_label`.
+    """
+    shaped = getattr(value, "type", None)
+    shape = getattr(shaped, "shape", None)
+    if shape is None or getattr(value, "is_splat", False):
+        return None
+
+    # More than one element. A dynamic dimension counts as many, since a shape that
+    # is not known here is not a scalar.
+    if all(0 <= dimension <= 1 for dimension in shape):
+        return None
+
+    element_type = str(getattr(shaped, "element_type", ""))
+    return shaped if _FLOAT_ELEMENT_TYPE.match(element_type) else None
+
+
+def _payload_digest(value: Any) -> str | None:
+    """
+    A hash of a parameter's bytes computed here, or `None` if they are out of reach.
+
+    Inline payloads support the buffer protocol, so they hash directly without being
+    printed. Resource-backed ones expose nothing -- no buffer, no accessor, no blob
+    manager, and printing the op yields only the handle -- so those return `None` and
+    `_weight_label` falls back to the compiler's hash.
+    """
+    try:
+        return hashlib.sha256(memoryview(value)).hexdigest()[:32]
+    except TypeError:
+        return None
+
+
+def _weight_label(
+    value: Any,
+    shaped: Any,
+    policy: WeightPolicy,
+    blobs: Mapping[str, str],
+    types: bool = True,
+) -> str:
+    """
+    What stands in for a parameter's payload.
+
+    Under `IGNORE`, its type alone, so shape and dtype are still compared while the
+    values are not. Under `DIGEST`, an inline payload is hashed here from its buffer and
+    a resource-backed one is compared by its **blob name** -- the compiler's own hash of
+    exactly those bytes (`getBlobNameForData`), which it already trusts to dedup blobs
+    without comparing them.
+
+    Two consequences of borrowing that hash, neither avoidable:
+
+    * **Handles are comparable only within one process.** `llvm::hash_value` is seeded
+      per execution in assertions builds, by design, and a handle is serialised into a
+      `.aimodel` rather than recomputed on load -- so two saved assets name identical
+      weights differently. Nothing in the handle reveals this, so the caller must know:
+      see `compute_coreai_program_diff`, and `DIGEST_PORTABLE` for the fix.
+    * **Inline and resource-backed payloads are digested in different spaces.** Harmless:
+      identical bytes imply an identical size and so the same storage form.
+
+    A payload offering neither route warns rather than passing quietly.
+    """
+    if policy is WeightPolicy.IGNORE:
+        # Keep the shape out of the structural label, which a reshaped op has to pair
+        # on. Carrying it there leaves every parameter of a widened model unable to
+        # pair, reported as added and removed rather than modified.
+        return f"<elided> : {shaped}" if types else "<elided>"
+
+    digest = _payload_digest(value)
+    if digest is not None:
+        return f"<sha:{digest}> : {shaped}"
+
+    text = str(value)
+    handle = _RESOURCE_REF.search(text)
+    if handle is not None:
+        # A digest read out of the module beats the compiler's name, because it does
+        # not depend on which process computed it.
+        resolved = blobs.get(handle.group(1))
+        return f"<sha:{resolved}> : {shaped}" if resolved else f"{text} : {shaped}"
+
+    logger.warning(
+        "Cannot compare the values of a %s parameter: it offers no buffer to hash "
+        "and no resource handle to compare. Its type is compared instead.",
+        shaped,
+    )
+    return f"{text} : {shaped}"
+
+
+def _resource_label(value: Any, policy: WeightPolicy, blobs: Mapping[str, str]) -> str:
+    """
+    A payload compared by value, with any resource handle taken out of the label.
+
+    A handle is a content hash with a **per-execution seed**, serialised into a
+    `.aimodel` and never recomputed on load, so two saved assets name byte-identical
+    weights differently and a label carrying one reports a difference that does not
+    exist. What replaces it depends on what the policy can honestly claim:
+
+    * `DIGEST_PORTABLE` -- the blob's real digest, read from the module. Exact.
+    * `DIGEST` -- the handle itself, valid only between two programs one process
+      produced, which is what the policy promises and no more.
+    * `IGNORE` -- nothing, keeping the type. This path matters because a *quantised*
+      weight is an `si4` payload, which `_is_parameter` does not claim, so a 4-bit
+      model's weights reach here with their handles intact.
+
+    Args:
+        value: The attribute to render.
+        policy: What the caller is willing to claim about parameter values.
+        blobs: Digests by blob name, empty unless `DIGEST_PORTABLE` is in force.
+
+    Returns:
+        The attribute as text, with any handle replaced by something stable.
+
+    """
+    text = str(value)
+    if policy is WeightPolicy.DIGEST or "dense_resource<" not in text:
+        return text
+
+    def substitute(match: re.Match[str]) -> str:
+        digest = blobs.get(match.group(1))
+        return f"dense_resource<sha:{digest}>" if digest else "dense_resource<elided>"
+
+    return _RESOURCE_REF.sub(substitute, text)
+
+
+def _attr_digest(
+    attrs: dict[str, Any],
+    policy: WeightPolicy,
+    blobs: Mapping[str, str],
+    types: bool = True,
+) -> str:
+    """
+    A digest of an op's own attributes.
+
+    Parameter payloads are left out by default and per-conversion symbol suffixes
+    normalised away: both differ between two conversions of one unchanged model, so
+    including either reports a change that did not happen. Read through the bindings,
+    never by parsing printed IR.
+    """
+    ir_object = attrs.get("ir_object")
+    operation = getattr(ir_object, "operation", ir_object)
+    attributes = getattr(operation, "attributes", None)
+    if attributes is None:
+        return ""
+
+    parts: list[str] = []
+    for attribute in attributes:
+        name = str(attribute.name)
+        if name in _UNSTABLE_ATTRS:
+            continue
+
+        shaped = _is_parameter(attribute.attr)
+        text = (
+            _weight_label(attribute.attr, shaped, policy, blobs, types)
+            if shaped is not None
+            else _resource_label(attribute.attr, policy, blobs)
+        )
+        text = _SYMBOL_SUFFIX.sub(_SYMBOL_KEPT, text)
+        parts.append(f"{name}={_DISPLAY_NAME.sub(_DISPLAY_NAME_KEPT, text)}")
+
+    return "|".join(sorted(parts))
+
+
+def resource_digests(module: Any) -> dict[str, str]:
+    """
+    Hash every resource blob in a module, by the name that module knows it under.
+
+    Makes two `.aimodel` assets comparable: a blob name is seeded per execution, so two
+    assets hold different names for identical weights.
+
+    TODO: expose a blob reader in `MLIRModule.cpp` (the inverse of
+    `create_elements_attr`) to make `DIGEST` portable and retire this function.
+
+    Args:
+        module: The MLIR module to read, as `program._mlir_module`.
+
+    Returns:
+        A digest per resource blob name, empty if the module cannot be printed.
+
+    """
+    try:
+        text = module.operation.get_asm(large_elements_limit=None)
+    except Exception:  # noqa: BLE001 - a module we cannot print yields no digests
+        logger.warning("Could not print the module; resource digests unavailable")
+        return {}
+
+    _, _, trailer = text.rpartition("dialect_resources:")
+
+    return {
+        name: hashlib.sha256(payload.encode()).hexdigest()[:32]
+        for name, payload in _RESOURCE_BLOB.findall(trailer)
+    }
+
+
+def _module_of(graph: nx.DiGraph) -> Any | None:
+    """
+    The module a graph's nodes live in, by climbing one node's parents.
+
+    `None` for a graph with no IR behind it -- built by hand, or a torch FX graph --
+    where there is nothing to print and nothing to digest.
+    """
+    for _, attrs in graph.nodes(data=True):
+        ir_object = attrs.get("ir_object")
+        node = getattr(ir_object, "operation", ir_object)
+        if node is None:
+            continue
+
+        while (parent := getattr(node, "parent", None)) is not None:
+            node = parent
+
+        return node
+
+    return None
+
+
+def _graph_blobs(graph: nx.DiGraph) -> dict[str, str]:
+    """
+    Resource digests for whatever module a graph came from.
+
+    So `DIGEST_PORTABLE` needs nothing threaded in: the module is one parent hop from
+    any op the graph holds. A program with composites therefore pays the print once
+    per graph rather than once per program -- accepted, because the alternative is two
+    more parameters on every function between here and the caller.
+    """
+    module = _module_of(graph)
+    return resource_digests(module) if module is not None else {}
+
+
+def _result_types(attrs: dict[str, Any]) -> str:
+    """
+    The types an op produces, which is where shape and dtype live.
+
+    What keeps a weight *shape* change visible while its values are ignored: a
+    constant's result type carries both.
+    """
+    ir_object = attrs.get("ir_object")
+    operation = getattr(ir_object, "operation", ir_object)
+    results = getattr(operation, "results", None)
+    if results is None:
+        return ""
+
+    try:
+        return ",".join(str(result.type) for result in results)
+    except Exception:  # noqa: BLE001 - a node without usable results is unlabelled
+        return ""
+
+
+@dataclass(frozen=True)
+class Label:
+    """
+    What makes a node the node it is, field by field.
+
+    Frozen, so it hashes and compares as a unit exactly as the string it replaces
+    did -- while a consumer that needs to say *which* part differs can read the field
+    by name. It was a `\x1f`-joined string, split back apart by `graph_diff` against
+    a tuple of field names kept in that other module: two places to hold in step, and
+    a `\x1f` inside any attribute value would have silently shifted every field after
+    it.
+
+    Attributes:
+        kind: `op`, `value`, `region`, `block` -- what sort of node this is.
+        op_name: The operation's name, empty for a node that is not one.
+        index: Position among its siblings, which is semantic for a block argument.
+        value_type: How a value came about: an op result, a block argument.
+        ir_type: A value's own type, where its shape and dtype live.
+        attributes: A digest of the op's attributes; see `_attr_digest`.
+        results: The types an operation produces.
+
+    """
+
+    kind: str = ""
+    op_name: str = ""
+    index: str = ""
+    value_type: str = ""
+    ir_type: str = ""
+    attributes: str = ""
+    results: str = ""
+
+
+# A node with no label at all -- absent from the mapping, or never labelled. Every
+# real node has at least a kind, so this collides with none of them.
+_NO_LABEL = Label()
+
+
+def _labels(
+    graph: nx.DiGraph,
+    policy: WeightPolicy,
+    blobs: Mapping[str, str],
+    types: bool,
+) -> dict[int, Label]:
+    """The shared body of `node_labels` and `structural_labels`."""
+    return {
+        node: Label(
+            kind=str(attrs.get("type", "")),
+            op_name=str(attrs.get("op_name", "")),
+            index=str(attrs.get("index", "")),
+            value_type=str(attrs.get("value_type", "")),
+            ir_type=str(attrs.get("ir_type", "")) if types else "",
+            attributes=_attr_digest(attrs, policy, blobs, types),
+            results=_result_types(attrs) if types else "",
+        )
+        for node, attrs in graph.nodes(data=True)
+    }
+
+
+def node_labels(
+    graph: nx.DiGraph,
+    policy: WeightPolicy = WeightPolicy.IGNORE,
+    blobs: Mapping[str, str] | None = None,
+) -> dict[int, Label]:
+    """
+    Everything that makes each node the node it is, as a comparable string.
+
+    The label a pair is *verified* against; `structural_labels` is the weaker key
+    pairs are proposed on. Result types are in it because a program graph is
+    bipartite and a value's shape and dtype live in its own `ir_type` -- left out,
+    every value node in a graph shared one label and could pair with a value of any
+    type.
+
+    Reads each node's `ir_object`, so the graph's program must still be alive; see
+    the note on lifetime in this module's docstring.
+
+    Args:
+        graph: The graph to label.
+        policy: Whether parameter values count towards identity.
+        blobs: Resource digests for this graph's module, from `resource_digests`.
+            Read only under `WeightPolicy.DIGEST_PORTABLE`.
+
+    Returns:
+        A label per node id.
+
+    """
+    return _labels(graph, policy, blobs or {}, types=True)
+
+
+def structural_labels(graph: nx.DiGraph) -> dict[int, Label]:
+    """
+    What makes each node that node *apart from the data flowing through it*.
+
+    The same label without result types, `ir_type` or parameter payloads -- an op's
+    kind, name, position and configuration. Those three are precisely what an edit
+    changes about an op that is *still the same op*, and a node whose label differs
+    cannot pair at all, so including them made every such edit read as one op removed
+    and an unrelated one added.
+
+    Pairs proposed on this key are verified against `node_labels`, so over-matching
+    costs precision, never correctness.
+
+    Args:
+        graph: The graph to label.
+
+    Returns:
+        A label per node id.
+
+    """
+    return _labels(graph, WeightPolicy.IGNORE, {}, types=False)
+
+
+# The edge from an operation to a value it produces, which is how a changed value
+# node is traced back to the operation responsible for it.
+_DEFINES_EDGE = "defines"
+
+# The node kind that stands for an operation. The graph is bipartite -- everything
+# else is a value, a region or a block -- and the distinction matters wherever a
+# difference has to be attributed to something a reader would recognise.
+_OP_NODE = "op"
+
+
+def defining_op(graph: nx.DiGraph, node_id: int) -> int | None:
+    """
+    The operation whose result a value node is, if it is one.
+
+    Args:
+        graph: The graph the node belongs to.
+        node_id: A value node.
+
+    Returns:
+        The producing operation, or `None` for a block argument -- a graph input is
+        not produced by an operation, so there is nothing to attribute it to.
+
+    """
+    for producer, _, data in graph.in_edges(node_id, data=True):
+        if (
+            data.get("edge_type") == _DEFINES_EDGE
+            and graph.nodes[producer].get("type") == _OP_NODE
+        ):
+            return producer
+
+    return None
+
+
+def responsible_op(graph: nx.DiGraph, node_id: int) -> int | None:
+    """
+    The operation a changed node is about: itself, or whatever produced it.
+
+    A program graph is bipartite, so a difference lands on a value node as readily as
+    on an op node, and reading only op nodes loses the rest outright -- a rewiring
+    inside a callee body put both its modifications on value nodes, and the diff
+    reported nothing modified at all.
+
+    Args:
+        graph: The graph the node belongs to.
+        node_id: Any node.
+
+    Returns:
+        The operation to report against, or `None` when nothing can be held
+        responsible -- a block argument, a region or a block, none of which an
+        operation produced. On a torch FX graph every node is an op, so this is the
+        identity.
+
+    """
+    if graph.nodes[node_id].get("type") == _OP_NODE:
+        return node_id
+
+    return defining_op(graph, node_id)
+
+
+def _ordered(graph: nx.DiGraph) -> list[int]:
+    """Producers before consumers, falling back to id order on a cycle."""
+    try:
+        return list(nx.topological_sort(graph))
+    except nx.NetworkXUnfeasible:
+        logger.warning("Graph has a cycle; falling back to id order")
+        return sorted(graph.nodes())
+
+
+def _operands(graph: nx.DiGraph, node: int) -> list[tuple[str, int, int]]:
+    """Incoming edges as `(edge_type, index, producer)`, in a stable order."""
+    return sorted(
+        (
+            str(data.get("edge_type", "")),
+            int(data.get("index", 0)),
+            producer,
+        )
+        for producer, _, data in graph.in_edges(node, data=True)
+    )
+
+
+def _hash(tag: str, label: Label, edges: list[tuple[str, int, str]]) -> str:
+    """
+    One node's fingerprint: a domain tag, its label, and its neighbours' hashes.
+
+    The tag separates the two hash spaces. `fingerprints` and `co_fingerprints` are
+    both compared against candidates from the other side, and a leaf has no operands
+    while a terminator has no consumers -- so without a tag the two would agree on
+    nodes that are not alike, having hashed the same label over an empty edge list.
+
+    Edges are sorted by their *hashes*, never by node id: numbering is an artefact of
+    traversal order and must not reach the hash.
+    """
+    return hashlib.sha256(repr((tag, label, sorted(edges))).encode()).hexdigest()
+
+
+def fingerprints(graph: nx.DiGraph, labels: dict[int, Label]) -> dict[int, str]:
+    """
+    A hash per node covering its label and, recursively, its operands'.
+
+    Equal fingerprints mean two nodes compute the same thing from the same inputs --
+    far stronger than sharing an op name, which every `add` in a model does.
+
+    Args:
+        graph: The graph to hash.
+        labels: Node labels, from `node_labels` or `structural_labels`.
+
+    Returns:
+        A hash per node id.
+
+    """
+    hashes: dict[int, str] = {}
+    for node in _ordered(graph):
+        hashes[node] = _hash(
+            "operands",
+            labels.get(node, _NO_LABEL),
+            [
+                (edge_type, index, hashes.get(producer, _MISSING))
+                for edge_type, index, producer in _operands(graph, node)
+            ],
+        )
+
+    return hashes
+
+
+def _consumers(graph: nx.DiGraph, node: int) -> list[tuple[str, int, int]]:
+    """Outgoing edges as `(edge_type, index, consumer)`, in a stable order."""
+    return sorted(
+        (
+            str(data.get("edge_type", "")),
+            int(data.get("index", 0)),
+            consumer,
+        )
+        for _, consumer, data in graph.out_edges(node, data=True)
+    )
+
+
+@dataclass(frozen=True)
+class _Adjacency:
+    """
+    Every node's neighbours, derived once per graph.
+
+    `nx` rebuilds an edge view on each access, and every pass here wants the same
+    two lists per node -- profiled on an 851-node graph, `_operands` was called
+    14,580 times and `_consumers` 11,194, all recomputing the same answers inside
+    `_propagate`'s loop.
+
+    Slots hold a *list* per `(edge_type, index)`, not one neighbour: a value feeding
+    several ops puts them all in `(operand, 0)`, and keeping only one silently
+    dropped the rest -- on a 71-node graph four values lost consumers that way, one
+    of them three of four.
+
+    Attributes:
+        operands: Incoming edges per node, as `(edge_type, index, producer)`.
+        consumers: Outgoing edges per node, as `(edge_type, index, consumer)`.
+        operand_slots: The same operands, grouped by `(edge_type, index)`.
+        consumer_slots: The same consumers, grouped by `(edge_type, index)`.
+        context: Each node's neighbours two hops out; see `_context`.
+
+    """
+
+    operands: dict[int, list[tuple[str, int, int]]]
+    consumers: dict[int, list[tuple[str, int, int]]]
+    operand_slots: dict[int, dict[tuple[str, int], list[int]]]
+    consumer_slots: dict[int, dict[tuple[str, int], list[int]]]
+    context: dict[int, set[int]]
+
+
+def _slots(
+    edges: list[tuple[str, int, int]],
+) -> dict[tuple[str, int], list[int]]:
+    """Neighbours grouped by the slot they occupy."""
+    groups: dict[tuple[str, int], list[int]] = defaultdict(list)
+    for edge_type, index, neighbor in edges:
+        groups[(edge_type, index)].append(neighbor)
+
+    return groups
+
+
+def _context(
+    operands: dict[int, list[tuple[str, int, int]]],
+    consumers: dict[int, list[tuple[str, int, int]]],
+) -> dict[int, set[int]]:
+    """
+    Each node's neighbours **two** hops out, ignoring direction and slot.
+
+    Two, not one, because a program graph is bipartite: one hop from an op reaches only
+    the values it reads and writes, which are themselves unmatched when a region is
+    rearranged. Direction and slot are dropped deliberately -- they are what every other
+    pass keys on, and exactly what a relocation changes.
+    """
+    adjacent = {
+        node: {producer for _, _, producer in operands[node]}
+        | {consumer for _, _, consumer in consumers[node]}
+        for node in operands
+    }
+
+    return {
+        node: set().union(*(adjacent[near] for near in near_nodes)) - {node}
+        if near_nodes
+        else set()
+        for node, near_nodes in adjacent.items()
+    }
+
+
+def _adjacency(graph: nx.DiGraph) -> _Adjacency:
+    """Read every edge once, in the order the comparison relies on."""
+    operands = {node: _operands(graph, node) for node in graph.nodes}
+    consumers = {node: _consumers(graph, node) for node in graph.nodes}
+
+    return _Adjacency(
+        operands=operands,
+        consumers=consumers,
+        operand_slots={node: _slots(edges) for node, edges in operands.items()},
+        consumer_slots={node: _slots(edges) for node, edges in consumers.items()},
+        context=_context(operands, consumers),
+    )
+
+
+def co_fingerprints(graph: nx.DiGraph, labels: dict[int, Label]) -> dict[int, str]:
+    """
+    A hash per node covering its label and, recursively, its *consumers'*.
+
+    The complement of `fingerprints`, and necessary because a producer-side hash
+    cannot recognise a node whose inputs changed but whose role did not -- the output
+    of a chain that grew a stage still ends the chain. Hashing from the uses inward
+    recognises it, so an insertion leaves one node over instead of orphaning
+    everything after it.
+
+    Args:
+        graph: The graph to hash.
+        labels: Node labels, from `node_labels` or `structural_labels`.
+
+    Returns:
+        A hash per node id.
+
+    """
+    hashes: dict[int, str] = {}
+    for node in reversed(_ordered(graph)):
+        hashes[node] = _hash(
+            "consumers",
+            labels.get(node, _NO_LABEL),
+            [
+                (edge_type, index, hashes.get(consumer, _MISSING))
+                for edge_type, index, consumer in _consumers(graph, node)
+            ],
+        )
+
+    return hashes
+
+
+@dataclass(frozen=True)
+class _Side:
+    """
+    One graph, and everything the comparison derives from it.
+
+    `align` needs six things per graph, and every one of them was a `source_`/
+    `target_` pair of locals threaded separately through the passes -- ten in all,
+    where passing the wrong one of a pair is a silent, plausible-looking bug. As one
+    value, a pass takes two arguments instead of six and cannot mix them up.
+
+    Attributes:
+        graph: The graph itself.
+        order: Its nodes, producers before consumers.
+        adjacency: Every node's neighbours, read once.
+        identity: The full label per node, which pairs are *verified* against.
+        structure: The weaker label, which pairs are *proposed* on.
+        hashes: Bottom-up fingerprints of the identity labels.
+
+    """
+
+    graph: nx.DiGraph
+    order: list[int]
+    adjacency: _Adjacency
+    identity: dict[int, Label]
+    structure: dict[int, Label]
+    hashes: dict[int, str]
+
+
+def _side(graph: nx.DiGraph, weights: WeightPolicy) -> _Side:
+    """Everything `align` reads from one graph, derived once."""
+    blobs = _graph_blobs(graph) if weights is WeightPolicy.DIGEST_PORTABLE else None
+    identity = node_labels(graph, weights, blobs)
+
+    return _Side(
+        graph=graph,
+        order=_ordered(graph),
+        adjacency=_adjacency(graph),
+        identity=identity,
+        structure=structural_labels(graph),
+        hashes=fingerprints(graph, identity),
+    )
+
+
+def _extend_anchor(
+    mapping: dict[int, int],
+    source_hashes: dict[int, str],
+    target_hashes: dict[int, str],
+    source_order: list[int],
+    target_order: list[int],
+    unambiguous: bool = False,
+) -> None:
+    """
+    Anchor whatever is still unmatched, on a second set of hashes.
+
+    `unambiguous` requires the hash to name exactly one node on each side, and is for
+    a *weaker* key: there a collision means "indistinguishable under a key that
+    deliberately ignores things", not "interchangeable", so choosing arbitrarily among
+    them pushes correct pairs out. Pairing ambiguously on the structural key turned a
+    clean 16-node block addition into 20 added and 4 removed.
+    """
+    taken = set(mapping.values())
+    by_hash_target: dict[str, list[int]] = defaultdict(list)
+    for node in target_order:
+        if node not in taken:
+            by_hash_target[target_hashes[node]].append(node)
+
+    if unambiguous:
+        by_hash_source: dict[str, list[int]] = defaultdict(list)
+        for node in source_order:
+            if node not in mapping:
+                by_hash_source[source_hashes[node]].append(node)
+
+    for node in source_order:
+        if node in mapping:
+            continue
+
+        digest = source_hashes[node]
+        candidates = by_hash_target.get(digest)
+        if not candidates:
+            continue
+        if unambiguous and (len(candidates) > 1 or len(by_hash_source[digest]) > 1):
+            continue
+
+        mapping[node] = candidates.pop(0)
+
+
+def _anchor(
+    source_hashes: dict[int, str],
+    target_hashes: dict[int, str],
+    source_order: list[int],
+    target_order: list[int],
+) -> dict[int, int]:
+    """
+    Pair nodes that hash alike.
+
+    Several nodes sharing a fingerprint are interchangeable to anything that only
+    reads the graph -- three identical blocks -- so they are paired in topological
+    order: deterministic, and for equivalent nodes arbitrary by definition.
+
+    That arbitrary choice is wrong whenever one side has one fewer;
+    `_release_interchangeable` corrects it afterwards, from the consumers. Avoiding the
+    choice here is worse either way -- deferring ambiguous groups to `_propagate`
+    starves it of seeds, and keying leaves on their consumers makes a leaf move whenever
+    anything downstream does. Both try to recover an identity the label threw away; the
+    ambiguity is a consequence of eliding parameter values, which
+    `WeightPolicy.DIGEST` does not do.
+    """
+    by_hash_source: dict[str, list[int]] = defaultdict(list)
+    by_hash_target: dict[str, list[int]] = defaultdict(list)
+    for node in source_order:
+        by_hash_source[source_hashes[node]].append(node)
+    for node in target_order:
+        by_hash_target[target_hashes[node]].append(node)
+
+    mapping: dict[int, int] = {}
+    for digest, sources in by_hash_source.items():
+        targets = by_hash_target.get(digest)
+        if not targets:
+            continue
+
+        for source, target in zip(sources, targets):
+            mapping[source] = target
+
+    return mapping
+
+
+def _propagate(
+    mapping: dict[int, int],
+    source: _Side,
+    target: _Side,
+    source_labels: dict[int, Label],
+    target_labels: dict[int, Label],
+) -> None:
+    """
+    Grow the mapping outward from what is already matched, along dataflow.
+
+    The step that makes an edit cost what the edit is worth. A bottom-up fingerprint
+    changes for *every* node downstream of a change, so anchoring alone reports the
+    whole cone below it -- an edit early in a model costing far more than the same
+    edit at the end, for no reason but how much graph sits after it.
+
+    What rescues those nodes is that they are the same ops in the same slots, reached
+    from a neighbour already matched. So each matched pair hands its neighbours to
+    `try_pair`, keyed on `(edge_type, index)` -- both operands and consumers, so a
+    chain matches from either end -- and only the node whose operands genuinely
+    differ is left over.
+
+    `try_pair` never steals: a node already mapped stays mapped, which is what lets
+    this run repeatedly, on either label, with the earlier and more exact passes
+    always winning.
+
+    Driven by a worklist rather than by rescanning the mapping to a fixpoint. Only a
+    *newly* paired node can place a neighbour that could not be placed before, so
+    rescanning pairs that have already been examined finds nothing -- it just costs a
+    pass over the whole mapping for every round.
+    """
+    taken = set(mapping.values())
+    pending = deque(mapping.items())
+
+    def try_pair(source: int, target: int) -> None:
+        if source in mapping or target in taken:
+            return
+        if source_labels.get(source) != target_labels.get(target):
+            return
+
+        mapping[source] = target
+        taken.add(target)
+        pending.append((source, target))
+
+    while pending:
+        source_node, target_node = pending.popleft()
+        # Operands, then consumers keyed the same way, so a chain matches from
+        # either end.
+        for source_slots, target_slots in (
+            (source.adjacency.operand_slots, target.adjacency.operand_slots),
+            (source.adjacency.consumer_slots, target.adjacency.consumer_slots),
+        ):
+            neighbours = target_slots.get(target_node, {})
+            for slot, sources in source_slots.get(source_node, {}).items():
+                for producer, image in zip(sources, neighbours.get(slot, ())):
+                    try_pair(producer, image)
+
+
+def _interchangeable(side: _Side) -> set[int]:
+    """
+    Nodes that nothing in the graph tells apart -- only the pairing does.
+
+    A node qualifies when its label is shared *and* it has no operands, or all of its
+    operands qualify. A leaf with a shared label is genuinely indistinguishable:
+    verification reads its label, which is equal, and its operands, of which it has
+    none. So one may stand in for another, and the cascade carries that through the
+    value a leaf defines.
+
+    Under `IGNORE` this is exactly the parameter constants of one shape -- eliding the
+    values is what makes them interchangeable. Requiring a shared label keeps the
+    cascade to nodes there is really a choice about.
+
+    Args:
+        side: The graph to scan, with its labels and adjacency.
+
+    Returns:
+        The ids of the nodes that are interchangeable with some other node.
+
+    """
+    counts = Counter(side.identity.values())
+    released: set[int] = set()
+    for node in side.order:
+        if counts[side.identity.get(node, _NO_LABEL)] < 2:
+            continue
+
+        operands = side.adjacency.operands[node]
+        if not operands or all(producer in released for _, _, producer in operands):
+            released.add(node)
+
+    return released
+
+
+def _release_interchangeable(
+    mapping: dict[int, int],
+    source: _Side,
+    target: _Side,
+) -> list[tuple[int, int]]:
+    """
+    Unpair the interchangeable nodes, so their consumers can place them instead.
+
+    Anchoring pairs a group of interchangeable nodes in topological order, which is
+    arbitrary -- and wrong for every node after the missing one as soon as a side has one
+    fewer, so an edit to one op reads as several modified.
+
+    The choice is only arbitrary *in isolation*. By now the ops that use these nodes are
+    matched, and an operand slot on a matched pair says which node belongs to which, so
+    the pairing is dropped and `_propagate` redoes it from that context. Doing this
+    *after* propagation is what makes it work: deferring the same group beforehand leaves
+    propagation without seeds to grow from.
+
+    Returns what it released so `_restore_released` can put back whatever nothing
+    claimed. `_propagate` re-pairs only where labels are *equal*, so a released pair
+    whose labels differ -- `tensor<24xf32>` against `tensor<32xf32>` in a widened model --
+    can never be re-made by it, and without the restore is lost outright.
+
+    Args:
+        mapping: The candidate mapping, modified in place.
+        source: The "before" graph.
+        target: The "after" graph.
+
+    Returns:
+        The pairs removed from `mapping`, in the order they were removed.
+
+    """
+    sources = _interchangeable(source)
+    if not sources:
+        return []
+
+    targets = _interchangeable(target)
+    released = [
+        (source_node, target_node)
+        for source_node, target_node in mapping.items()
+        if source_node in sources and target_node in targets
+    ]
+    for source_node, _ in released:
+        del mapping[source_node]
+
+    return released
+
+
+def _restore_released(mapping: dict[int, int], released: list[tuple[int, int]]) -> None:
+    """
+    Put back any released pair that nothing else claimed.
+
+    So releasing can only ever improve the mapping: a pair the consumers re-made
+    differently is left as they made it, and one nobody wanted returns to what
+    anchoring had chosen. Both sides must still be free -- restoring over a pair
+    made since would undo the very repair the release was for.
+    """
+    taken = set(mapping.values())
+    for source, target in released:
+        if source in mapping or target in taken:
+            continue
+
+        mapping[source] = target
+        taken.add(target)
+
+
+def _assign_residual(
+    mapping: dict[int, int],
+    source: _Side,
+    target: _Side,
+) -> None:
+    """
+    Pair what is left over by best overall agreement, ignoring position entirely.
+
+    The general answer to a *relocation*, and the only pass that does not assume
+    something stayed put: every earlier pass keys on the cone below, the cone above or
+    the operand slot, and a move breaks all three at once, leaving an op that plainly
+    still exists paired with nothing.
+
+    What survives a move is *company* -- a relocated op still sits among the same ops.
+    So a pair is scored on how much of its 2-hop neighbourhood is already matched to the
+    other's (Jaccard), and the assignment maximising the total is taken: optimal, and
+    with no threshold to tune.
+
+    Only nodes with **equal identity labels** may pair, so this cannot invent a
+    correspondence between different ops, and only leftovers are considered, so it cannot
+    overrule a pass with better evidence. On a model with no relocation it pairs nothing.
+
+    Falls back to `_greedy_assignment` if `scipy` is unavailable, costing optimality on
+    the rare row with two plausible partners, not correctness.
+    """
+    unmatched_source = [node for node in source.order if node not in mapping]
+    if not unmatched_source:
+        return
+
+    taken = set(mapping.values())
+    unmatched_target = [node for node in target.order if node not in taken]
+    if not unmatched_target:
+        return
+
+    # A node's company, expressed in the *other* graph's terms where it is known.
+    company = {
+        node: {
+            mapping[near] for near in source.adjacency.context[node] if near in mapping
+        }
+        for node in unmatched_source
+    }
+
+    scores: dict[tuple[int, int], float] = {}
+    for source_node in unmatched_source:
+        label = source.identity.get(source_node)
+        known = company[source_node]
+        if not known:
+            continue
+
+        for target_node in unmatched_target:
+            if target.identity.get(target_node) != label:
+                continue
+
+            context = target.adjacency.context[target_node]
+            shared = known & context
+            if shared:
+                scores[(source_node, target_node)] = len(shared) / len(known | context)
+
+    for source_node, target_node in _best_assignment(
+        scores, unmatched_source, unmatched_target
+    ):
+        mapping[source_node] = target_node
+
+
+def _best_assignment(
+    scores: dict[tuple[int, int], float],
+    sources: list[int],
+    targets: list[int],
+) -> list[tuple[int, int]]:
+    """
+    The set of pairs with the greatest total score, at most one per node.
+
+    Optimal rather than greedy because the scores sit close together, so a greedy walk
+    takes whichever plausible partner it meets first rather than the best one.
+    `linear_sum_assignment` is the Hungarian algorithm (Kuhn, 1955), which maximises
+    the total and has no threshold to tune.
+    """
+    if not scores:
+        return []
+
+    # Only nodes that scored at all can be assigned, and the scores are sparse: a
+    # node is comparable with the few that share its label, not with every leftover.
+    # Ordered by `sources`/`targets` so the matrix is deterministic.
+    scored_sources = {source_node for source_node, _ in scores}
+    scored_targets = {target_node for _, target_node in scores}
+    rows = [node for node in sources if node in scored_sources]
+    columns = [node for node in targets if node in scored_targets]
+
+    if _linear_sum_assignment is None:  # pragma: no cover - scipy is a dependency
+        return _greedy_assignment(scores)
+
+    row_of = {node: index for index, node in enumerate(rows)}
+    column_of = {node: index for index, node in enumerate(columns)}
+    matrix = _numpy.zeros((len(rows), len(columns)))
+    for (source_node, target_node), score in scores.items():
+        matrix[row_of[source_node], column_of[target_node]] = score
+
+    return [
+        (rows[row], columns[column])
+        for row, column in zip(*_linear_sum_assignment(-matrix))
+        if matrix[row, column] > 0
+    ]
+
+
+def _greedy_assignment(
+    scores: dict[tuple[int, int], float],
+) -> list[tuple[int, int]]:
+    """
+    Best-first pairing, for when `scipy` is not installed.
+
+    Costs optimality on a row with two plausible partners, not correctness: every
+    pair it makes is one the optimal assignment could also have made.
+    """
+    chosen_sources: set[int] = set()
+    chosen_targets: set[int] = set()
+    pairs = []
+    for source_node, target_node in sorted(
+        scores, key=lambda pair: (-scores[pair], pair)
+    ):
+        if source_node in chosen_sources or target_node in chosen_targets:
+            continue
+
+        chosen_sources.add(source_node)
+        chosen_targets.add(target_node)
+        pairs.append((source_node, target_node))
+
+    return pairs
+
+
+def _verify(
+    mapping: dict[int, int],
+    source: _Side,
+    target: _Side,
+) -> tuple[dict[int, int], list[tuple[int, int]]]:
+    """
+    Split a candidate mapping into pairs that correspond exactly and pairs that do not.
+
+    The step that makes the rest safe to be heuristics. Anchoring and propagation
+    both *guess*; nothing before this point has checked a guess. A pair survives only
+    if its full labels agree and its operands correspond one for one -- same slot, and
+    the producer this mapping pairs it with -- and anything else is `modified` rather
+    than quietly accepted, which is exactly the defect that let a rewiring report as
+    no change at all.
+
+    Operands are compared as multisets, not as a slot dict, so two operands sharing a
+    slot are both checked instead of one shadowing the other.
+    """
+    verified: dict[int, int] = {}
+    modified: list[tuple[int, int]] = []
+
+    for source_node, target_node in mapping.items():
+        if source.identity.get(source_node) != target.identity.get(target_node):
+            modified.append((source_node, target_node))
+            continue
+
+        mapped = Counter(
+            (edge_type, index, mapping.get(producer, _UNMAPPED))
+            for edge_type, index, producer in source.adjacency.operands[source_node]
+        )
+        if mapped == Counter(target.adjacency.operands[target_node]):
+            verified[source_node] = target_node
+        else:
+            modified.append((source_node, target_node))
+
+    return verified, modified
+
+
+def _is_isomorphism(
+    verified: dict[int, int],
+    modified: list[tuple[int, int]],
+    source_graph: nx.DiGraph,
+    target_graph: nx.DiGraph,
+) -> bool:
+    """
+    Whether a verified mapping proves the two graphs are the same graph.
+
+    The whole argument: every pair in `verified` maps each operand to the
+    corresponding operand, so every source edge maps to a distinct target edge. If the
+    mapping is also a node bijection and the edge counts agree, that injection is onto
+    -- an isomorphism, under labels.
+
+    Comparing the two fingerprint *multisets* instead is not sound: a bottom-up
+    fingerprint says nothing about how often a value is consumed, so a duplicated
+    constant with one copy dead hashes exactly like a shared one.
+    """
+    node_count = source_graph.number_of_nodes()
+
+    return (
+        not modified
+        and len(verified) == node_count
+        and target_graph.number_of_nodes() == node_count
+        and len(set(verified.values())) == node_count
+        and source_graph.number_of_edges() == target_graph.number_of_edges()
+    )
+
+
+def align(
+    source_graph: nx.DiGraph,
+    target_graph: nx.DiGraph,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
+) -> Alignment:
+    """
+    Which node of `source_graph` became which node of `target_graph`.
+
+    Args:
+        source_graph: The "before" graph.
+        target_graph: The "after" graph.
+        weights: Whether a parameter's values are part of an op's identity.
+            `IGNORE` by default: parameters are re-initialised on every rebuild, so
+            comparing their values reports every diff as a total rewrite. Shapes and
+            dtypes are compared either way. `DIGEST` compares the values too, at
+            no meaningful cost, but only between programs this process produced;
+            `DIGEST_PORTABLE` also works for programs loaded from disk, and pays a
+            print of each graph's module for it -- see `resource_digests`.
+
+    Returns:
+        An `Alignment`. `identical` is a certificate rather than a guess: it holds
+        only when the verified mapping is a complete bijection that accounts for
+        every edge, which is a proof the graphs are the same graph.
+
+    """
+    # Two labels per node, and the difference between them is the point. Pairs are
+    # proposed on the structural label, so an op that is still the same op is
+    # recognised when its shape or its weights moved; they are verified against the
+    # full label, so such a pair is reported as *modified* rather than accepted.
+    # Proposing on the full label made a reshaped op read as an unrelated op removed
+    # and another added, leaving nothing to say which one changed.
+    source = _side(source_graph, weights)
+    target = _side(target_graph, weights)
+
+    # Pass 1, the exact key: anchor equal fingerprints, from the producers up and
+    # then from the uses inward, and grow both outward along dataflow. Every pair
+    # made here is exact, which is what makes it safe to grow from.
+    candidate = _anchor(source.hashes, target.hashes, source.order, target.order)
+    _extend_anchor(
+        candidate,
+        co_fingerprints(source.graph, source.identity),
+        co_fingerprints(target.graph, target.identity),
+        source.order,
+        target.order,
+    )
+
+    # Propagation runs *before* the weaker key, not after: growing from exact pairs
+    # places the neighbours of a change correctly and leaves the structural pass less
+    # to guess at. Propagating on the weaker key here instead turned a clean 16-node
+    # block addition into 20 added and 4 removed, because once types are ignored a
+    # slot-mate of the wrong shape becomes a candidate.
+    _propagate(candidate, source, target, source.identity, target.identity)
+
+    # Pass 2, the weaker key: whatever the exact key could not place, but only where
+    # it names exactly one node on each side. A collision here means "indistinguishable
+    # once types are ignored", which is not the same as "interchangeable".
+    for weak in (fingerprints, co_fingerprints):
+        _extend_anchor(
+            candidate,
+            weak(source.graph, source.structure),
+            weak(target.graph, target.structure),
+            source.order,
+            target.order,
+            unambiguous=True,
+        )
+
+    _propagate(candidate, source, target, source.structure, target.structure)
+
+    # Pass 3: redo the one choice nothing informed -- which of a group of genuinely
+    # interchangeable nodes is which -- now that their consumers are matched and can
+    # answer it. Then re-anchor on the identity fingerprints, so a released node no
+    # consumer claimed (a dead constant) lands where it would have before.
+    released = _release_interchangeable(candidate, source, target)
+    _propagate(candidate, source, target, source.identity, target.identity)
+    _extend_anchor(candidate, source.hashes, target.hashes, source.order, target.order)
+    _restore_released(candidate, released)
+
+    # Pass 4, the last resort: whatever is still unpaired, matched on the company it
+    # keeps rather than on where it sits. This is what recognises a *move*.
+    _assign_residual(candidate, source, target)
+
+    verified, modified = _verify(candidate, source, target)
+
+    matched_targets = set(verified.values()) | {target for _, target in modified}
+    matched_sources = set(verified) | {source for source, _ in modified}
+
+    return Alignment(
+        mapping=verified,
+        removed=[node for node in source.order if node not in matched_sources],
+        added=[node for node in target.order if node not in matched_targets],
+        modified=modified,
+        identical=_is_isomorphism(verified, modified, source.graph, target.graph),
+    )

--- a/coreai_torch/debugging/table_writer.py
+++ b/coreai_torch/debugging/table_writer.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Shared table rendering for the debugging tools.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import Protocol, TextIO, runtime_checkable
+
+from rich.console import Console, RenderableType
+from rich.table import Table
+from typing_extensions import Self
+
+_DEFAULT_WIDTH = 150
+"""Console width used when the destination stream has no detectable width."""
+
+
+@dataclass(frozen=True)
+class _Column:
+    """One column of a :class:`_TableSpec`."""
+
+    header: str
+    """Column heading."""
+
+    justify: str = "left"
+    """Cell alignment: ``"left"``, ``"center"``, or ``"right"``."""
+
+    style: str = ""
+    """`rich` style applied to every cell in the column (e.g. ``"bold green"``)."""
+
+    no_wrap: bool = False
+    """Whether to keep cells on one line. Defaults to False so a value that does
+    not fit wraps within its column instead of being cut off."""
+
+    overflow: str = "fold"
+    """How to handle content wider than the column: ``"fold"`` (wrap onto the
+    next line), ``"ellipsis"``, or ``"crop"``. Defaults to folding so no text is
+    lost.
+    """
+
+
+@dataclass(frozen=True)
+class _Row:
+    """One row of a :class:`_TableSpec`."""
+
+    cells: tuple[str, ...]
+    """Cell values, one per :class:`_Column`, already formatted as text."""
+
+    style: str = ""
+    """`rich` style applied to the whole row (e.g. ``"red"`` for a removed op)."""
+
+
+@runtime_checkable
+class _TableRow(Protocol):
+    """
+    Something that can render itself as a table row.
+
+    Implementing this keeps a single formatting definition per record type, so a
+    row's cells cannot drift from the header that describes them.
+    """
+
+    def to_row(self: Self) -> _Row:
+        """
+        Return this object's cells.
+
+        Returns:
+            The :class:`_Row` describing this object.
+
+        """
+        ...
+
+
+@dataclass
+class _TableSpec:
+    """A table to render: a title, its columns, and its rows."""
+
+    title: str
+    """Table title, written above the table."""
+
+    columns: tuple[_Column, ...]
+    """Column definitions, left to right."""
+
+    rows: list[_Row] = field(default_factory=list)
+    """Rows, in display order."""
+
+    caption: str | None = None
+    """Optional caption written below the table (e.g. a truncation note)."""
+
+    show_lines: bool = False
+    """Whether to rule between rows. Turn this on when cells wrap, so it stays
+    clear where one row ends and the next begins."""
+
+    row_spacing: int = 0
+    """Blank lines below each row's content. One line of spacing keeps rows of
+    wrapped text from reading as a single block."""
+
+    def add(self: Self, row: _Row | _TableRow) -> None:
+        """
+        Append a row, accepting either a :class:`_Row` or a :class:`_TableRow`.
+
+        Args:
+            row: _Row to append, or an object that can produce one.
+
+        """
+        self.rows.append(row if isinstance(row, _Row) else row.to_row())
+
+
+def _make_console(
+    output: TextIO | None = None,
+    *,
+    width: int | None = None,
+    color: bool | None = None,
+    soft_wrap: bool = False,
+) -> Console:
+    """
+    Build a `rich` console writing to *output*.
+
+    Args:
+        output: Destination stream. Defaults to ``sys.stdout`` when None.
+        width: Console width. Defaults to :data:`_DEFAULT_WIDTH`, since an
+            in-memory stream has no width to detect.
+        color: Force color on or off. When None, `rich` decides from the stream
+            (colors for a terminal, plain text otherwise).
+        soft_wrap: When True, lines are emitted whole instead of being wrapped to
+            the console width. Use it for content whose line breaks matter, such
+            as annotated source.
+
+    Returns:
+        A console configured for the given stream.
+
+    """
+    stream = sys.stdout if output is None else output
+    return Console(
+        file=stream,
+        width=_DEFAULT_WIDTH if width is None else width,
+        no_color=None if color is None else not color,
+        highlight=False,
+        soft_wrap=soft_wrap,
+        markup=False,
+    )
+
+
+def _write_renderable(
+    renderable: RenderableType,
+    output: TextIO | None = None,
+    *,
+    width: int | None = None,
+    color: bool | None = None,
+) -> None:
+    """
+    Write any `rich` renderable (table, tree, text) to *output*.
+
+    Args:
+        renderable: The `rich` renderable to write.
+        output: Destination stream. Defaults to ``sys.stdout`` when None.
+        width: Console width. Defaults to :data:`_DEFAULT_WIDTH`.
+        color: Force color on or off. When None, `rich` decides from the stream.
+
+    """
+    _make_console(output, width=width, color=color).print(renderable)
+
+
+def _build_table(spec: _TableSpec) -> Table:
+    """
+    Build a `rich` table from *spec* without rendering it.
+
+    Useful when the table has to be composed with other renderables before being
+    written.
+
+    Args:
+        spec: Description of the table.
+
+    Returns:
+        The `rich` table.
+
+    """
+    table = Table(
+        title=spec.title,
+        title_justify="left",
+        caption=spec.caption,
+        caption_justify="left",
+        header_style="bold",
+        show_lines=spec.show_lines,
+        # (top, right, bottom, left): keep the usual one-space side padding and
+        # add the requested blank lines below each row's content.
+        padding=(0, 1, spec.row_spacing, 1),
+    )
+    for column in spec.columns:
+        table.add_column(
+            column.header,
+            justify=column.justify,
+            style=column.style or None,
+            no_wrap=column.no_wrap,
+            overflow=column.overflow,
+        )
+    for row in spec.rows:
+        table.add_row(*row.cells, style=row.style or None)
+    return table
+
+
+def _write_table(
+    spec: _TableSpec,
+    output: TextIO | None = None,
+    *,
+    width: int | None = None,
+    color: bool | None = None,
+) -> None:
+    """
+    Render *spec* to *output*.
+
+    Args:
+        spec: Description of the table.
+        output: Destination stream. Defaults to ``sys.stdout`` when None.
+        width: Console width. Defaults to :data:`_DEFAULT_WIDTH`.
+        color: Force color on or off. When None, `rich` decides from the stream.
+
+    """
+    _write_renderable(_build_table(spec), output, width=width, color=color)


### PR DESCRIPTION
Diffing two programs asked whether their graphs were isomorphic, then discarded the verdict and rebuilt a diff from scratch -- VF2 accounted for 72.83s of a 74.11s Qwen3 comparison for an answer nothing used. Matching now runs in linear time with no search: nodes are labelled, fingerprinted bottom-up, anchored where fingerprints agree, and propagated along dataflow so an edit stays local instead of implicating everything downstream of it.

Reporting gains a third outcome. An operation that still exists but is wired or configured differently is modified, rather than an unrelated removal plus addition. Weight values remain excluded by default, since re-exporting a model reinitializes them; WeightPolicy.DIGEST and DIGEST_PORTABLE opt into comparing them for callers asking where two builds actually differ.