### PR TITLE
Extract source annotation into its own modules

### DIFF
--- a/coreai_torch/debugging/annotations.py
+++ b/coreai_torch/debugging/annotations.py
@@ -1,0 +1,268 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Annotation rendering shared by the source and program annotators.
+
+An :class:`_Annotation` renders one operation's information as comment lines. The
+annotators differ in *where* those lines go -- above a Python source line, or
+beside a line of the printed Core AI program -- but not in how they are rendered,
+so :class:`_AnnotatedListing` owns the rendering for both.
+
+Styling is expressed as `rich` style names rather than ANSI escapes, so colour is
+applied for a terminal and dropped for a file or in-memory stream.
+
+:class:`_Annotation`, :class:`_TextAnnotation`, and :data:`_AnnotationCallback` are
+re-exported by :mod:`~coreai_torch.debugging.source_annotator`; everything else
+here is internal to the annotators.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, TextIO, runtime_checkable
+
+from coreai._compiler.ir import Operation
+from rich.console import Console
+from rich.text import Text
+from typing_extensions import Self
+
+from .table_writer import _make_console
+
+_ANNOTATION_STYLE = "green"
+"""Default style for an annotation comment."""
+
+_DETAIL_STYLE = "yellow"
+"""Style for a secondary line under an annotation (e.g. a validation message)."""
+
+# Rendering one line at a time would build a console per call, so consoles are
+# kept per output stream. The cache stays tiny: an annotator writes to one stream.
+_CONSOLES: dict[int, tuple[TextIO, Console]] = {}
+
+
+def _console_for(output: TextIO) -> Console:
+    """
+    Get a console writing to *output*, reusing one per stream.
+
+    Args:
+        output: Destination stream.
+
+    Returns:
+        A console for that stream.
+
+    """
+    key = id(output)
+    cached = _CONSOLES.get(key)
+    if cached is not None and cached[0] is output:
+        return cached[1]
+    if len(_CONSOLES) > 8:
+        _CONSOLES.clear()
+    console = _make_console(output, soft_wrap=True)
+    _CONSOLES[key] = (output, console)
+    return console
+
+
+def _write_line(output: TextIO, text: str, style: str = "") -> None:
+    """
+    Write one styled line to *output*.
+
+    Lines are never wrapped, so a long annotation stays on one line and source
+    text is reproduced as-is.
+
+    Args:
+        output: Destination stream.
+        text: Line contents, without a trailing newline.
+        style: `rich` style name, or empty for unstyled output.
+
+    """
+    _console_for(output).print(Text(text, style=style or None))
+
+
+@dataclass(frozen=True)
+class _AnnotationLine:
+    """One line of an annotation, before a comment prefix or indent is applied."""
+
+    text: str
+    """Line contents, without a comment marker."""
+
+    style: str = _ANNOTATION_STYLE
+    """`rich` style name. Empty string renders the line unstyled."""
+
+    indent: str = ""
+    """Extra indentation, for a line subordinate to the one above it."""
+
+
+@runtime_checkable
+class _Annotation(Protocol):
+    """
+    Something that can describe itself as annotation lines.
+
+    An annotation supplies text; the listing decides the comment marker and the
+    indentation, so the same annotation reads correctly above Python source and
+    beside a line of printed Core AI.
+    """
+
+    def lines(self: Self) -> Iterable[_AnnotationLine]:
+        """
+        Return the lines describing this annotation.
+
+        Returns:
+            The lines, in display order.
+
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class _TextAnnotation:
+    """Default :class:`_Annotation`: a single comment line."""
+
+    text: str
+    """Annotation text, rendered after the listing's comment prefix."""
+
+    color: str = _ANNOTATION_STYLE
+    """`rich` style name for the comment. Empty string renders it unstyled."""
+
+    def lines(self: Self) -> Iterable[_AnnotationLine]:
+        """
+        Return this annotation as a single line.
+
+        Returns:
+            One :class:`_AnnotationLine` holding the text.
+
+        """
+        return (_AnnotationLine(self.text, self.color),)
+
+    def write(self: Self, output: TextIO) -> None:
+        """
+        Write the annotation as a standalone comment line.
+
+        Convenience for rendering one annotation outside a listing; a listing
+        applies its own prefix and indent instead.
+
+        Args:
+            output: Text stream to write the annotation to.
+
+        """
+        _write_line(output, f"# {self.text}", self.color)
+
+
+# Maps an operation to its _Annotation, or None to skip it.
+_AnnotationCallback = Callable[[Operation], "_Annotation | None"]
+
+
+class _Placement(Enum):
+    """Where an annotation goes relative to the line it describes."""
+
+    ABOVE = "above"
+    """On its own line(s) before the annotated line, as in annotated source."""
+
+    TRAILING = "trailing"
+    """After the annotated line's text, as in an annotated program listing."""
+
+
+@dataclass
+class _AnnotatedListing:
+    """
+    Text lines together with the annotations attached to them.
+
+    Both annotators reduce to this: a list of lines, and a mapping from 1-based
+    line number to the annotations describing that line.
+    """
+
+    lines: list[str]
+    """Lines of text, without trailing newlines."""
+
+    annotations: dict[int, list[_Annotation]] = field(default_factory=dict)
+    """Annotations per 1-based line number, in the order they should appear."""
+
+    header: str | None = None
+    """Optional header written above the listing."""
+
+    placement: _Placement = _Placement.ABOVE
+    """Whether annotations precede their line or follow it."""
+
+    comment_prefix: str = "#"
+    """Comment marker for annotation lines. ``"//"`` for a Core AI program."""
+
+    align_to_line: bool = False
+    """Whether to indent an annotation to the line it describes.
+
+    Reads naturally in a program listing, where an annotation sits inside the
+    region its operation belongs to. Left off for source, where annotations
+    precede the line and a fixed column keeps them scannable.
+    """
+
+    def annotate(self: Self, number: int, annotation: _Annotation) -> None:
+        """
+        Attach an annotation to a line.
+
+        Args:
+            number: 1-based line number the annotation describes.
+            annotation: _Annotation to attach.
+
+        """
+        self.annotations.setdefault(number, []).append(annotation)
+
+    def extend(self: Self, number: int, annotations: Iterable[_Annotation]) -> None:
+        """
+        Attach several annotations to a line.
+
+        Args:
+            number: 1-based line number the annotations describe.
+            annotations: Annotations to attach, in display order.
+
+        """
+        for annotation in annotations:
+            self.annotate(number, annotation)
+
+    def _write_annotations(
+        self: Self,
+        output: TextIO,
+        annotations: Iterable[_Annotation],
+        described: str,
+    ) -> None:
+        """
+        Write the annotations describing one line.
+
+        Args:
+            output: Text stream to write to.
+            annotations: Annotations to write, in display order.
+            described: The line they describe, whose indentation they follow when
+                :attr:`align_to_line` is set.
+
+        """
+        margin = ""
+        if self.align_to_line:
+            margin = described[: len(described) - len(described.lstrip())]
+        for annotation in annotations:
+            for line in annotation.lines():
+                _write_line(
+                    output,
+                    f"{margin}{self.comment_prefix}{line.indent} {line.text}",
+                    line.style,
+                )
+
+    def write(self: Self, output: TextIO) -> None:
+        """
+        Write the listing with its annotations.
+
+        Args:
+            output: Text stream to write to.
+
+        """
+        if self.header is not None:
+            _write_line(output, self.header, _ANNOTATION_STYLE)
+
+        for number, text in enumerate(self.lines, start=1):
+            attached = self.annotations.get(number, ())
+            if self.placement is _Placement.ABOVE:
+                self._write_annotations(output, attached, text)
+                _write_line(output, text)
+            elif self.placement is _Placement.TRAILING:
+                _write_line(output, text)
+                self._write_annotations(output, attached, text)

--- a/coreai_torch/debugging/benchmarker.py
+++ b/coreai_torch/debugging/benchmarker.py
@@ -19,7 +19,7 @@ Key components:
 import logging
 import threading
 from abc import ABC, abstractmethod
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -34,7 +34,10 @@ from coreai.authoring import AIProgram
 from coreai.runtime import AIModel, NDArray, Profiler, SpecializationOptions
 from typing_extensions import Self
 
+from .annotations import _ANNOTATION_STYLE, _write_line
 from .debug_info import DebugInfoRecord, parse_debug_infos
+from .source_annotator import _read_source_file, _should_exclude_location
+from .utils import LocationInfo, get_operation_locations
 
 logger = logging.getLogger(__name__)
 
@@ -182,100 +185,6 @@ class Measurement:
         )
 
 
-@dataclass(frozen=True)
-class _LocationInfo:
-    """Location information for an operation."""
-
-    filename: str
-    """Source filename."""
-
-    line: int
-    """Line number."""
-
-    col: int
-    """Column number."""
-
-
-def _get_operation_locations(operation: Operation) -> list[_LocationInfo]:
-    """
-    Extract file/line/col locations from an operation.
-
-    Args:
-        operation: Operation to extract locations from
-
-    Returns:
-        List of unique LocationInfo objects (duplicates filtered, order preserved)
-
-    """
-    file_line_cols = _mlir.get_file_line_col_locations(operation.location)  # type: ignore[attr-defined]
-
-    # Convert to LocationInfo
-    locations = [
-        _LocationInfo(
-            filename=loc.filename,
-            line=loc.line,
-            col=loc.col,
-        )
-        for loc in file_line_cols
-    ]
-
-    # Remove duplicates while preserving order using OrderedDict
-    return list(reversed(OrderedDict.fromkeys(locations)))
-
-
-def _default_location_exclude(location: _LocationInfo) -> bool:
-    """
-    Exclude locations based on default filtering rules.
-
-    Excludes files from known torch package roots (torch, torchaudio, torchvision, etc.),
-    exported_program.py, and "-".
-
-    Args:
-        location: LocationInfo to check
-
-    Returns:
-        True if location should be excluded, False otherwise
-
-    """
-    # Convert to Path for consistent comparison
-    file_path = Path(location.filename)
-
-    # Known torch package names that should be excluded
-    torch_packages = {"torch", "torchaudio", "torchvision", "torchtext", "torchdata"}
-
-    # Check for exact matches of known torch package roots
-    has_torch_package = any(part in torch_packages for part in file_path.parts)
-
-    return (
-        has_torch_package
-        or file_path.name == "exported_program.py"
-        or location.filename == "-"
-    )
-
-
-def _read_source_file(file_path: Path, output: TextIO) -> list[str] | None:
-    """
-    Read source file and return lines, or write error and return None.
-
-    Args:
-        file_path: Path to the source file to read
-        output: Text stream to write errors to
-
-    Returns:
-        List of source lines, or None if file couldn't be read
-
-    """
-    try:
-        with open(file_path) as f:
-            return f.readlines()
-    except FileNotFoundError:
-        output.write(f"# Error: File not found: {file_path}\n")
-        return None
-    except Exception as e:
-        output.write(f"# Error reading file: {e}\n")
-        return None
-
-
 def _group_operations_by_line(
     module_timing: "ModuleTiming",
     file_path: Path,
@@ -296,7 +205,7 @@ def _group_operations_by_line(
     )
 
     for operation, timing in module_timing.get_all_operations():
-        locations = _get_operation_locations(operation)
+        locations = get_operation_locations(operation)
 
         for loc in locations:
             # Match by filename (handle both absolute and relative paths)
@@ -316,8 +225,13 @@ def _annotate_source_file(
     """
     Annotate a source file with timing information from a module.
 
-    Reads the source file, finds operations from that file in the module,
-    and writes the annotated source with colored timing comments before each line.
+    Reads the source file, finds operations from that file in the module, and
+    writes the annotated source with a timing comment before each annotated line.
+
+    The comment is styled by name rather than by escape code, so colour is applied
+    for a terminal and dropped for a file or in-memory stream. Writing the escapes
+    unconditionally left them in the text of every saved listing, which a terminal
+    renders and an editor shows as noise.
 
     Args:
         module_timing: ModuleTiming to get operation timings from
@@ -326,10 +240,6 @@ def _annotate_source_file(
 
     """
     file_path = Path(file_path)
-
-    # ANSI color codes
-    green = "\033[92m"
-    reset = "\033[0m"
 
     # Read the source file
     source_lines = _read_source_file(file_path, output)
@@ -353,9 +263,11 @@ def _annotate_source_file(
                     )
 
             if timings_for_line:
-                # Write colored annotation comment on line before
-                annotation = "# " + ", ".join(timings_for_line)
-                output.write(f"{green}{annotation}{reset}\n")
+                # Indent the comment to match the line it describes, so the
+                # annotated listing stays readable as Python.
+                margin = line_content[: len(line_content) - len(line_content.lstrip())]
+                annotation = margin + "# " + ", ".join(timings_for_line)
+                _write_line(output, annotation, _ANNOTATION_STYLE)
 
         # Write the original source line
         output.write(line_content)
@@ -493,7 +405,7 @@ class ModuleTiming:
 
     def get_operations_at_location(
         self: Self,
-        location: _LocationInfo,
+        location: LocationInfo,
     ) -> list[tuple[Operation, OperationTiming]]:
         """
         Find operations at a specific source location.
@@ -512,7 +424,7 @@ class ModuleTiming:
 
         # Search all operations in this module and children
         for operation, timing in self.get_all_operations():
-            op_locations = _get_operation_locations(operation)
+            op_locations = get_operation_locations(operation)
 
             # Check if any of the operation's locations match
             for op_loc in op_locations:
@@ -529,7 +441,7 @@ class ModuleTiming:
     def annotate_dominant_source(
         self: Self,
         output: TextIO,
-        exclude: Callable[[_LocationInfo], bool] | None = None,
+        exclude: Callable[[LocationInfo], bool] | None = None,
     ) -> None:
         """
         Find the dominant source file and annotate it with timing information.
@@ -546,14 +458,14 @@ class ModuleTiming:
         """
         # Use default exclusion if not provided
         if exclude is None:
-            exclude = _default_location_exclude
+            exclude = _should_exclude_location
 
         # Count occurrences of each source file from locations
         file_counts: dict[str, int] = defaultdict(int)
         # Only use operations from this module, not children
         for operation, _ in self.operation_timings:
             # Get file/line/col locations
-            locations = _get_operation_locations(operation)
+            locations = get_operation_locations(operation)
 
             if locations:
                 # Take the last file (innermost)

--- a/coreai_torch/debugging/comparator.py
+++ b/coreai_torch/debugging/comparator.py
@@ -250,23 +250,23 @@ class Comparator(
     @staticmethod
     def _get_status_display(status: Status) -> tuple[str, str]:
         """
-        Get color and symbol for a status.
+        Get the style and symbol for a status.
+
+        The style is a `rich` style name rather than an ANSI escape, so a caller
+        passing it to
+        :func:`~coreai_torch.debugging.annotations._write_line` gets colour on a
+        terminal and plain text in a file.
 
         Returns:
-            Tuple of (color_code, status_symbol)
+            Tuple of (style_name, status_symbol)
 
         """
-        # ANSI color codes
-        green = "\033[92m"
-        red = "\033[91m"
-        yellow = "\033[93m"
-
         if status == Comparator.Status.PASS:
-            return green, "✓"
+            return "green", "✓"
         elif status == Comparator.Status.FAIL:
-            return red, "✗"
+            return "red", "✗"
         else:
-            return yellow, "?"
+            return "yellow", "?"
 
     def _sort_statuses_by_topo_order(
         self,

--- a/coreai_torch/debugging/debug_info.py
+++ b/coreai_torch/debugging/debug_info.py
@@ -8,8 +8,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TextIO
 
 import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
 from coreai._compiler._mlir_libs._coreaiIR._bindings.mlir import (
@@ -25,6 +26,12 @@ from coreai_torch._debug_locations import (
     _create_unknown_location_with_operation_id,
     _get_nested_operations,
 )
+
+from .table_writer import _Column, _Row, _TableSpec, _write_table
+
+# Stand-in filename for a location that carries only an operation id, with no real
+# source position behind it. Left out of a rendered summary.
+_OP_ID_PSEUDO_FILE = "op_id"
 
 
 @dataclass
@@ -228,6 +235,30 @@ class Metadata:
         )
 
 
+def _format_metadata_value(value: Metadata.Value) -> str:
+    """
+    Render a metadata value as a single-line string.
+
+    Args:
+        value: Metadata value to render.
+
+    Returns:
+        Text for the value: scalars as themselves, arrays as ``[a, b]``,
+        dictionaries as ``{key: value}``, and a unit value as ``"set"``.
+
+    """
+    if value.value_type == "array" and isinstance(value.value, list):
+        return "[" + ", ".join(_format_metadata_value(v) for v in value.value) + "]"
+    if value.value_type == "dictionary" and isinstance(value.value, dict):
+        items = ", ".join(
+            f"{key}: {_format_metadata_value(v)}" for key, v in value.value.items()
+        )
+        return "{" + items + "}"
+    if value.value_type == "unit":
+        return "set"
+    return "" if value.value is None else str(value.value)
+
+
 @dataclass(frozen=True)
 class DebugInfo:
     """Represents debug information for a single operation."""
@@ -429,6 +460,130 @@ class DebugInfo:
         """
         return [m.value for m in self.metadatas if m.key == key]
 
+    def format_source_locations(self) -> str:
+        """
+        Render this operation's source locations as text.
+
+        Returns:
+            The locations as ``file:line:col``, separated by ``"; "``, or an
+            empty string when the operation records no real source location.
+
+        """
+        return "; ".join(
+            f"{location.file_name}:{location.line}:{location.column}"
+            for location in self.source_locations
+            if location.file_name != _OP_ID_PSEUDO_FILE
+        )
+
+    def metadata_keys(self) -> tuple[str, ...]:
+        """
+        Distinct metadata keys on this operation, in first-appearance order.
+
+        A key may appear more than once (e.g. one ``op_id`` per dialect level);
+        it is reported once here, and :meth:`format_metadata` joins its values.
+
+        Returns:
+            The unique metadata keys.
+
+        """
+        return tuple(dict.fromkeys(metadata.key for metadata in self.metadatas))
+
+    def op_id_levels(self) -> tuple[str, ...]:
+        """
+        Dialect levels this operation records an ``op_id`` for.
+
+        An operation carries one ``op_id`` entry per level it was traced through
+        (``torch``, ``coreai``, ``odix``, ``MPSGraph``, ...), so the levels are
+        what turn a single ``op_id`` key into one column per level.
+
+        Returns:
+            The levels, in first-appearance order.
+
+        """
+        levels: list[str] = []
+        for metadata in self.metadatas:
+            if metadata.key != "op_id":
+                continue
+            if metadata.value.value_type != "dictionary" or not isinstance(
+                metadata.value.value,
+                dict,
+            ):
+                continue
+            level = self._get_str_field(metadata.value.value, "type")
+            if level is not None and level not in levels:
+                levels.append(level)
+        return tuple(levels)
+
+    def format_op_ids(self, level: str) -> str:
+        """
+        Render this operation's ``op_id`` values for *level* as text.
+
+        Repeats are collapsed, keeping first-appearance order. An entry standing
+        for a fused kernel records one metadata block per operation it absorbed,
+        so the same id appears in several blocks. :meth:`get_op_ids` still returns
+        the raw values, since that multiplicity says how many blocks reference an
+        id.
+
+        Args:
+            level: Dialect level name (e.g. ``"torch"``, ``"coreai"``).
+
+        Returns:
+            The distinct ids separated by ``", "``, or an empty string when the
+            operation records no id for *level*.
+
+        """
+        return ", ".join(
+            str(op_id) for op_id in dict.fromkeys(self.get_op_ids(level=level))
+        )
+
+    def format_metadata(self, key: str) -> str:
+        """
+        Render every metadata value recorded under *key* as text.
+
+        Args:
+            key: Metadata key to render.
+
+        Returns:
+            The values separated by ``", "``, or an empty string when the
+            operation records no metadata under *key*.
+
+        """
+        return ", ".join(
+            _format_metadata_value(value) for value in self.get_all_metadata(key)
+        )
+
+    def to_row(
+        self,
+        metadata_keys: Sequence[str],
+        op_id_levels: Sequence[str] = (),
+    ) -> _Row:
+        """
+        Render this operation as a table row.
+
+        Args:
+            metadata_keys: Keys to emit as columns, in column order. A key this
+                operation does not carry yields an empty cell, so rows from
+                different operations stay aligned.
+            op_id_levels: Dialect levels to emit as their own columns, in column
+                order. These come before the metadata columns, and ``"op_id"``
+                should be left out of *metadata_keys* when they are used.
+
+        Returns:
+            A :class:`~coreai_torch.debugging.table_writer._Row` holding the ODIX
+            id, name, source locations, one cell per op-id level, and one cell
+            per requested metadata key.
+
+        """
+        return _Row(
+            cells=(
+                str(self.odix_id),
+                self.name,
+                self.format_source_locations(),
+                *(self.format_op_ids(level) for level in op_id_levels),
+                *(self.format_metadata(key) for key in metadata_keys),
+            ),
+        )
+
     def get_output_mappings(self, source_level: str) -> list[OutputMapping]:
         """
         Get output mappings from source level by parsing metadata.
@@ -491,6 +646,153 @@ class DebugInfoRecord:
         return [
             info for info in self.operations if info.get_op_id("torch") == torch_op_id
         ]
+
+    def metadata_keys(self) -> tuple[str, ...]:
+        """
+        Union of the metadata keys carried by this record's operations.
+
+        Ordered by first appearance, so the resulting columns follow the data
+        rather than an arbitrary sort.
+
+        Returns:
+            The unique metadata keys across all operations.
+
+        """
+        return tuple(
+            dict.fromkeys(
+                key
+                for operation in self.operations
+                for key in operation.metadata_keys()
+            )
+        )
+
+    def op_id_levels(self) -> tuple[str, ...]:
+        """
+        Union of the dialect levels this record's operations record ids for.
+
+        Returns:
+            The levels (``"torch"``, ``"coreai"``, ``"odix"``, ...), ordered by
+            first appearance.
+
+        """
+        return tuple(
+            dict.fromkeys(
+                level
+                for operation in self.operations
+                for level in operation.op_id_levels()
+            )
+        )
+
+    def _build_summary(
+        self,
+        *,
+        metadata_keys: Sequence[str] | None = None,
+        op_id_levels: Sequence[str] | None = None,
+        max_operations: int | None = None,
+    ) -> _TableSpec:
+        """
+        Build the table of this record's operations without rendering it.
+
+        Each row is one operation, holding its ODIX id, name, and source
+        locations, then one ``op_id[<level>]`` cell per dialect level, then one
+        cell per remaining metadata key. Operations that do not carry a given
+        level or key leave that cell empty.
+
+        ``op_id`` is split per level rather than shown as one column: an
+        operation records one id per level it was traced through, so a single
+        column would read ``{value: 210, type: torch}, {value: 497, type:
+        coreai}`` and the ids could not be compared down a column.
+
+        Returning the spec lets a caller read the same headers and cells that
+        :meth:`write_summary` would print, instead of parsing rendered text.
+
+        Args:
+            metadata_keys: Keys to include as columns. Defaults to
+                :meth:`metadata_keys` minus ``op_id``, which is covered by
+                *op_id_levels*.
+            op_id_levels: Dialect levels to include as ``op_id[<level>]``
+                columns. Defaults to :meth:`op_id_levels`, i.e. every level in
+                this record. Pass an empty sequence to drop them.
+            max_operations: Maximum number of operations to include. Defaults to
+                all of them; when set, the caption reports how many were dropped.
+
+        Returns:
+            The :class:`~coreai_torch.debugging.table_writer._TableSpec` for this
+            record.
+
+        """
+        levels = (
+            tuple(op_id_levels) if op_id_levels is not None else self.op_id_levels()
+        )
+        if metadata_keys is not None:
+            keys = tuple(metadata_keys)
+        else:
+            # op_id is rendered as one column per level, so drop it from the
+            # generic metadata columns to avoid showing the same data twice.
+            keys = tuple(key for key in self.metadata_keys() if key != "op_id")
+
+        operations = self.operations
+        caption = None
+        if max_operations is not None and len(operations) > max_operations:
+            caption = (
+                f"showing {max_operations} of {len(operations)} operations "
+                f"(... and {len(operations) - max_operations} more)"
+            )
+            operations = operations[:max_operations]
+
+        spec = _TableSpec(
+            title=f"Debug info: {self.identifier} ({len(self.operations)} operations)",
+            columns=(
+                _Column("odix_id", justify="right"),
+                _Column("name"),
+                _Column("source locations"),
+                *(_Column(f"op_id[{level}]", justify="right") for level in levels),
+                *(_Column(key) for key in keys),
+            ),
+            caption=caption,
+            show_lines=True,
+            row_spacing=1,
+        )
+        for operation in operations:
+            spec.add(operation.to_row(keys, levels))
+        return spec
+
+    def write_summary(
+        self,
+        output: TextIO | None = None,
+        *,
+        metadata_keys: Sequence[str] | None = None,
+        op_id_levels: Sequence[str] | None = None,
+        max_operations: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        """
+        Write a table of this record's operations, one column per metadata key.
+
+        Renders what :meth:`_build_summary` describes; see it for the column
+        layout. Cells wrap rather than truncate, so a row is as tall as its
+        longest value needs and no text is lost. Records carry many keys, so pass
+        a larger *width*, or a subset of *metadata_keys*, when columns end up
+        narrow.
+
+        Args:
+            output: Text stream to write the table to. Defaults to
+                ``sys.stdout`` when None.
+            metadata_keys: Keys to render as columns. See :meth:`_build_summary`.
+            op_id_levels: Dialect levels to render as ``op_id[<level>]`` columns.
+                See :meth:`_build_summary`.
+            max_operations: Maximum number of operations to list. See
+                :meth:`_build_summary`.
+            width: Console width to render at. Defaults to
+                :data:`~coreai_torch.debugging.table_writer._DEFAULT_WIDTH`.
+
+        """
+        spec = self._build_summary(
+            metadata_keys=metadata_keys,
+            op_id_levels=op_id_levels,
+            max_operations=max_operations,
+        )
+        _write_table(spec, output, width=width)
 
 
 def parse_debug_infos(debug_infos_bytes: bytes) -> list[DebugInfoRecord]:

--- a/coreai_torch/debugging/source_annotator.py
+++ b/coreai_torch/debugging/source_annotator.py
@@ -1,0 +1,580 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Generic source annotation for Core AI operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections import OrderedDict, defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Self, TextIO
+
+import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
+from coreai._compiler.ir import Operation
+from coreai.authoring import AIProgram
+
+from .annotations import (
+    _AnnotatedListing,
+    _Annotation,
+    _AnnotationCallback,
+    _TextAnnotation,
+    _write_line,
+)
+from .utils import LocationInfo, _walk_operations, get_operation_locations
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_Annotation",
+    "_AnnotationCallback",
+    "ModulePath",
+    "_SourceAnnotator",
+    "_TextAnnotation",
+    "_annotate_operations",
+    "_annotate_source",
+    "_operation_in_module",
+    "_should_exclude_location",
+]
+
+
+# Module instance path from an operation's stack trace, outermost first (e.g.
+# ("HierarchicalModel$1", "SubModel$2")). Disambiguates instances of the same
+# submodule that share a source file/line.
+ModulePath = tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _AttributedAnnotation:
+    """An annotation together with the module instance it was attributed to."""
+
+    annotation: _Annotation
+    """The annotation produced by the callback."""
+
+    module: ModulePath
+    """Stack-trace module path of the originating operation (may be empty)."""
+
+
+def _distinct_files_innermost_first(
+    locations: list[LocationInfo],
+) -> list[str]:
+    """
+    List the distinct source files of an operation, innermost first.
+
+    Walks locations from innermost outward, collapsing runs of consecutive
+    same-file locations into a single entry.
+
+    Args:
+        locations: Operation locations (outermost first, innermost last).
+
+    Returns:
+        Distinct filenames ordered innermost first.
+
+    """
+    distinct_files: list[str] = []
+    for loc in reversed(locations):
+        if not distinct_files or distinct_files[-1] != loc.filename:
+            distinct_files.append(loc.filename)
+    return distinct_files
+
+
+def _trim_excluded_leaf_modules(
+    module: ModulePath,
+    locations: list[LocationInfo],
+    exclude: Callable[[LocationInfo], bool],
+) -> ModulePath:
+    """
+    Drop trailing module frames whose innermost source files are excluded.
+
+    Leaf module frames (e.g. ``torch.nn.Linear``) often lack their own
+    annotatable file. For each innermost distinct source file that is excluded,
+    one trailing frame is dropped so the operation collapses into the parent
+    module that owns the annotatable line.
+
+    Args:
+        module: Stack-trace frames, outermost first.
+        locations: Operation locations (outermost first, innermost last).
+        exclude: Decides whether a source location is excluded.
+
+    Returns:
+        ``module`` with its excluded leaf frames removed.
+
+    """
+    excluded_leaves = 0
+    for filename in _distinct_files_innermost_first(locations):
+        if not exclude(LocationInfo(filename=filename, line=0, col=0)):
+            break
+        excluded_leaves += 1
+
+    if not excluded_leaves:
+        return module
+    return module[: max(0, len(module) - excluded_leaves)]
+
+
+def _get_module_path(
+    operation: Operation,
+    exclude: Callable[[LocationInfo], bool],
+) -> ModulePath:
+    """
+    Extract the trimmed module instance path from an operation's stack trace.
+
+    Each frame identifies a module instance (e.g. ``"SubModel$2"``), so the full
+    path distinguishes instances sharing a source location. Trailing (innermost)
+    frames whose source files are excluded are dropped, collapsing leaf modules
+    without their own annotatable file into the parent that owns the line.
+
+    Args:
+        operation: Operation to extract the module path from.
+        exclude: Decides whether a source location is excluded.
+
+    Returns:
+        Stack-trace frames (outermost first), trimmed of trailing frames without
+        their own annotatable file. Empty when there is no stack trace.
+
+    """
+    stack_trace = _mlir.get_stack_trace(operation.location)  # type: ignore[attr-defined]
+    if not stack_trace:
+        return ()
+
+    return _trim_excluded_leaf_modules(
+        tuple(stack_trace),
+        get_operation_locations(operation),
+        exclude,
+    )
+
+
+def _operation_in_module(operation: Operation, module: ModulePath) -> bool:
+    """
+    Check whether an operation belongs to a given module instance path.
+
+    Matches ``module`` against the prefix of the operation's stack trace
+    (outermost first), so an operation is considered part of ``module`` when it
+    originates from that module or any of its descendants. An empty ``module``
+    matches every operation.
+
+    Args:
+        operation: Operation whose stack trace is inspected.
+        module: Module instance path (outermost first) to match against.
+
+    Returns:
+        True if the operation belongs to ``module`` (or one of its children).
+
+    """
+    stack_trace = tuple(_mlir.get_stack_trace(operation.location) or ())  # type: ignore[attr-defined]
+    return stack_trace[: len(module)] == module
+
+
+def _should_exclude_location(location: LocationInfo) -> bool:
+    """
+    Default exclusion: torch package files, ``exported_program.py``, and ``"-"``.
+
+    Args:
+        location: LocationInfo to check.
+
+    Returns:
+        True if location should be excluded.
+
+    """
+    file_path = Path(location.filename)
+
+    torch_packages = {"torch", "torchaudio", "torchvision", "torchtext", "torchdata"}
+    has_torch_package = any(part in torch_packages for part in file_path.parts)
+
+    return (
+        has_torch_package
+        or file_path.name == "exported_program.py"
+        or location.filename == "-"
+    )
+
+
+def _read_source_file(file_path: Path, output: TextIO) -> list[str] | None:
+    """
+    Read source file lines, or write an error and return None.
+
+    Args:
+        file_path: Path to the source file to read.
+        output: Text stream to write errors to.
+
+    Returns:
+        Source lines, or None if the file couldn't be read.
+
+    """
+    try:
+        with open(file_path) as f:
+            return f.readlines()
+    except FileNotFoundError:
+        _write_line(output, f"# Error: File not found: {file_path}")
+        return None
+    except Exception as e:
+        _write_line(output, f"# Error reading file: {e}")
+        return None
+
+
+def _normalize_path(filename: str | Path) -> str:
+    """
+    Normalize a filename to a canonical absolute path string.
+
+    Used as the attribution dict key so lookups match regardless of how the path
+    is expressed. Falls back to the unresolved absolute path if resolution fails.
+
+    Args:
+        filename: Source filename to normalize.
+
+    Returns:
+        Canonical absolute path string for ``filename``.
+
+    """
+    path = Path(filename)
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path.absolute())
+
+
+class _SourceAnnotator:
+    """
+    Attribute per-operation annotations to source locations and render them.
+
+    Walks a collection of operations, asks a callback for each operation's
+    :class:`_Annotation`, and attributes it to the operation's dominant
+    (innermost, non-excluded) source location whose file exists on disk. Supports
+    :meth:`get_annotation` (look up annotations for a file/line) and
+    :meth:`write` (write annotated source with each annotation above its line).
+    """
+
+    def __init__(
+        self: Self,
+        operations: Iterable[Operation],
+        annotate: _AnnotationCallback,
+        *,
+        exclude: Callable[[LocationInfo], bool] | None = None,
+    ) -> None:
+        """
+        Build the annotation attribution map.
+
+        Args:
+            operations: Operations to annotate.
+            annotate: Maps each operation to its :class:`_Annotation`, or
+                ``None`` to skip it.
+            exclude: Optional source-location filter. Defaults to excluding torch
+                files, ``exported_program.py``, and ``"-"``.
+
+        """
+        self._exclude = exclude if exclude is not None else _should_exclude_location
+
+        # filename -> {line -> attributed annotations}
+        self._file_line_annotations: dict[
+            str,
+            dict[int, list[_AttributedAnnotation]],
+        ] = defaultdict(lambda: defaultdict(list))
+        # filename -> attribution count (for dominance).
+        self._file_counts: dict[str, int] = defaultdict(int)
+
+        for operation in operations:
+            annotation = annotate(operation)
+            if annotation is None:
+                continue
+            self._attribute(operation, annotation)
+
+    def _attribute(self: Self, operation: Operation, annotation: _Annotation) -> None:
+        """
+        Attribute an operation's annotation to its dominant source location.
+
+        Attributes to the innermost non-excluded location whose file exists. The
+        originating module instance is stored alongside so different instances of
+        the same submodule can be told apart.
+
+        Args:
+            operation: Operation the annotation belongs to.
+            annotation: _Annotation to attribute.
+
+        """
+        locations = get_operation_locations(operation)
+        valid_locations = [loc for loc in locations if not self._exclude(loc)]
+        if not valid_locations:
+            return
+
+        # Innermost valid location.
+        last_loc = valid_locations[-1]
+
+        # Only attribute to existing files so we can read them later.
+        if not Path(last_loc.filename).exists():
+            return
+
+        attributed = _AttributedAnnotation(
+            annotation=annotation,
+            module=_get_module_path(operation, self._exclude),
+        )
+        key = _normalize_path(last_loc.filename)
+        self._file_line_annotations[key][last_loc.line].append(attributed)
+        self._file_counts[key] += 1
+
+    @property
+    def files(self: Self) -> list[str]:
+        """
+        Source files with at least one attributed annotation.
+
+        Returns:
+            Filenames ordered by attribution count (descending); the first, when
+            present, is the dominant file.
+
+        """
+        return sorted(
+            self._file_counts,
+            key=lambda filename: self._file_counts[filename],
+            reverse=True,
+        )
+
+    @property
+    def dominant_file(self: Self) -> str | None:
+        """
+        The single most frequently attributed source file.
+
+        Returns:
+            The dominant filename, or ``None`` if nothing was attributed.
+
+        """
+        files = self.files
+        return files[0] if files else None
+
+    def get_annotation(
+        self: Self,
+        filename: str | Path,
+        line: int,
+        *,
+        module: ModulePath | None = None,
+    ) -> list[_Annotation]:
+        """
+        Get the annotations attributed to a given file and line.
+
+        Annotations at a file/line may come from different module instances; pass
+        ``module`` to restrict the result to one instance.
+
+        Args:
+            filename: Source file to look up.
+            line: 1-based line number within ``filename``.
+            module: Optional module instance path (from :meth:`modules_at`) to
+                filter by. None returns all instances at that location.
+
+        Returns:
+            Annotations attributed to that file/line (and module, when given).
+
+        """
+        line_annotations = self._file_line_annotations.get(_normalize_path(filename))
+        if line_annotations is None:
+            return []
+        return [
+            attributed.annotation
+            for attributed in line_annotations.get(line, [])
+            if module is None or attributed.module == module
+        ]
+
+    def modules_at(self: Self, filename: str | Path, line: int) -> list[ModulePath]:
+        """
+        Get the distinct module instance paths attributed to a file and line.
+
+        Args:
+            filename: Source file to look up.
+            line: 1-based line number within ``filename``.
+
+        Returns:
+            Unique module paths (order preserved) with annotations there.
+
+        """
+        line_annotations = self._file_line_annotations.get(_normalize_path(filename))
+        if line_annotations is None:
+            return []
+        return list(
+            OrderedDict.fromkeys(
+                attributed.module for attributed in line_annotations.get(line, [])
+            ),
+        )
+
+    def _modules_in_file(self: Self, filename: str | Path) -> list[ModulePath]:
+        """
+        Get the distinct module instance paths attributed anywhere in a file.
+
+        Args:
+            filename: Source file to look up.
+
+        Returns:
+            Unique module paths (order preserved) with annotations in the file.
+
+        """
+        line_annotations = self._file_line_annotations.get(_normalize_path(filename))
+        if line_annotations is None:
+            return []
+        modules: OrderedDict[ModulePath, None] = OrderedDict()
+        for attributed_list in line_annotations.values():
+            for attributed in attributed_list:
+                modules[attributed.module] = None
+        return list(modules)
+
+    def write(
+        self: Self,
+        output: TextIO | None = None,
+        *,
+        annotate_all_files: bool = False,
+    ) -> None:
+        """
+        Write annotated source to a text stream.
+
+        Reads the relevant source file(s) and writes them back with each
+        attributed annotation rendered above the corresponding line. A file
+        reached through multiple module instances is written once per instance,
+        each copy showing only that instance's annotations.
+
+        Args:
+            output: Text stream to write to. Defaults to ``sys.stdout``.
+            annotate_all_files: When True, annotate every attributed file
+                (ordered by count, descending). When False, only the dominant
+                file.
+
+        """
+        if output is None:
+            output = sys.stdout
+
+        files = self.files
+        if not files:
+            _write_line(output, "# No valid locations found in operations")
+            return
+
+        if not annotate_all_files:
+            files = files[:1]
+
+        for filename in files:
+            for module in self._modules_in_file(filename):
+                self._write_file(Path(filename), output, module=module)
+
+    def _build_listing(
+        self: Self,
+        file_path: Path,
+        source_lines: list[str],
+        *,
+        module: ModulePath,
+    ) -> _AnnotatedListing:
+        """
+        Build the listing for one source file and module instance.
+
+        Args:
+            file_path: Path to the annotated source file.
+            source_lines: Lines of that file, as read from disk.
+            module: Module instance whose annotations are included.
+
+        Returns:
+            The listing, with each annotation attached above its source line.
+
+        """
+        module_label = " -> ".join(module) if module else "<unknown>"
+        listing = _AnnotatedListing(
+            lines=[line.rstrip("\n") for line in source_lines],
+            header=f"\n# === {file_path} [{module_label}] ===",
+        )
+
+        line_annotations = self._file_line_annotations.get(
+            _normalize_path(file_path),
+            {},
+        )
+        for line_number, attributed_annotations in line_annotations.items():
+            listing.extend(
+                line_number,
+                (
+                    attributed.annotation
+                    for attributed in attributed_annotations
+                    if attributed.module == module
+                ),
+            )
+        return listing
+
+    def _write_file(
+        self: Self,
+        file_path: Path,
+        output: TextIO,
+        *,
+        module: ModulePath,
+    ) -> None:
+        """
+        Write a single source file with one module instance's annotations.
+
+        Args:
+            file_path: Path to the source file to annotate.
+            output: Text stream to write the annotated source to.
+            module: Module instance whose annotations are rendered (also shown in
+                the header).
+
+        """
+        source_lines = _read_source_file(file_path, output)
+        if source_lines is None:
+            return
+
+        self._build_listing(file_path, source_lines, module=module).write(output)
+
+
+def _annotate_operations(
+    operations: Iterable[Operation],
+    annotate: _AnnotationCallback,
+    output: TextIO | None = None,
+    *,
+    exclude: Callable[[LocationInfo], bool] | None = None,
+    annotate_all_files: bool = False,
+) -> None:
+    """
+    Annotate source for a collection of operations.
+
+    Convenience wrapper that builds a :class:`_SourceAnnotator` and writes its
+    output.
+
+    Args:
+        operations: Operations to annotate.
+        annotate: Maps each operation to its :class:`_Annotation`, or ``None`` to
+            skip it.
+        output: Text stream to write to. Defaults to ``sys.stdout``.
+        exclude: Optional source-location filter. Defaults to excluding torch
+            files, ``exported_program.py``, and ``"-"``.
+        annotate_all_files: When True, annotate every attributed file (ordered by
+            count, descending). When False, only the dominant file.
+
+    """
+    annotator = _SourceAnnotator(operations, annotate, exclude=exclude)
+    annotator.write(output, annotate_all_files=annotate_all_files)
+
+
+def _annotate_source(
+    coreai_program: AIProgram,
+    annotate: _AnnotationCallback,
+    output: TextIO | None = None,
+    *,
+    exclude: Callable[[LocationInfo], bool] | None = None,
+    annotate_all_files: bool = False,
+) -> None:
+    """
+    Annotate the source of an AIProgram.
+
+    Walks every operation in ``coreai_program`` and delegates to
+    :func:`_annotate_operations`.
+
+    Args:
+        coreai_program: AIProgram whose source should be annotated.
+        annotate: Maps each operation to its :class:`_Annotation`, or ``None`` to
+            skip it.
+        output: Text stream to write to. Defaults to ``sys.stdout``.
+        exclude: Optional source-location filter. Defaults to excluding torch
+            files, ``exported_program.py``, and ``"-"``.
+        annotate_all_files: When True, annotate every attributed file (ordered by
+            count, descending). When False, only the dominant file.
+
+    """
+    _annotate_operations(
+        _walk_operations(coreai_program),
+        annotate,
+        output,
+        exclude=exclude,
+        annotate_all_files=annotate_all_files,
+    )

--- a/coreai_torch/debugging/utils.py
+++ b/coreai_torch/debugging/utils.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Operation traversal shared by the debugging tools.
+
+The tools each need every operation in a program, including those nested inside
+composite graph bodies, so the walk lives here rather than being repeated per
+module.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
+from coreai._compiler.ir import Operation
+from coreai.authoring import AIProgram
+
+
+def _walk_operation(
+    operation: Operation, depth: int = 0
+) -> Iterator[tuple[Operation, int]]:
+    """
+    Walk *operation* and everything nested inside its regions.
+
+    Args:
+        operation: Operation to start from.
+        depth: Region nesting depth of *operation*, used for the values yielded
+            for its children.
+
+    Yields:
+        Each operation and its region nesting depth, parents before children.
+
+    """
+    resolved = getattr(operation, "operation", operation)
+    yield resolved, depth
+    for region in resolved.regions:
+        for block in region.blocks:
+            for child in block.operations:
+                yield from _walk_operation(child, depth + 1)
+
+
+def _walk_operations(coreai_program: AIProgram) -> list[Operation]:
+    """
+    Collect every operation in a program.
+
+    Args:
+        coreai_program: AIProgram to walk.
+
+    Returns:
+        The operations, parents before children.
+
+    """
+    module = coreai_program._mlir_module.operation
+    return [operation for operation, _ in _walk_operation(module)]
+
+
+@dataclass(frozen=True)
+class LocationInfo:
+    """
+    A source location attributed to a Core AI operation.
+    """
+
+    filename: str
+    """Source filename."""
+
+    line: int
+    """Line number."""
+
+    col: int
+    """Column number."""
+
+
+def get_operation_locations(operation: Operation) -> list[LocationInfo]:
+    """
+    Extract the source locations attributed to an operation.
+
+    Args:
+        operation: Operation to extract locations from.
+
+    Returns:
+        Unique locations, order preserved, innermost last.
+
+    """
+    file_line_cols = _mlir.get_file_line_col_locations(operation.location)  # type: ignore[attr-defined]
+
+    locations = [
+        LocationInfo(filename=loc.filename, line=loc.line, col=loc.col)
+        for loc in file_line_cols
+    ]
+
+    # Dedupe while preserving order.
+    return list(reversed(OrderedDict.fromkeys(locations)))

--- a/tests/debugging/test_source_annotator.py
+++ b/tests/debugging/test_source_annotator.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for the generic source annotator."""
+
+from io import StringIO
+
+import pytest
+import torch
+from coreai._compiler.ir import Operation
+from coreai.authoring import AIProgram
+
+from coreai_torch.converter import TorchConverter, _DebugInfoRecorder
+from coreai_torch.debugging.source_annotator import (
+    _annotate_source,
+    _Annotation,
+    _SourceAnnotator,
+    _TextAnnotation,
+    _walk_operations,
+)
+
+from .test_model import HierarchicalModel, get_example_inputs
+
+
+@pytest.fixture
+async def hierarchical_coreai_program() -> AIProgram:
+    """Fixture that provides a AIProgram from a hierarchical model."""
+    model = HierarchicalModel().eval()
+    example_inputs = get_example_inputs(HierarchicalModel)
+    exported_program = torch.export.export(model, args=tuple(example_inputs.values()))
+    exported_program = exported_program.run_decompositions()
+    converter: TorchConverter = TorchConverter()
+    converter._debug_info_recorder.config = _DebugInfoRecorder.Config(
+        include_stack_trace=True,
+        verify_debuginfo_locations=True,
+    )
+    converter.add_exported_program(exported_program, entrypoint_name="main")
+    coreai_program = converter.to_coreai()
+
+    return coreai_program
+
+
+def test_text_annotation_write_renders_comment() -> None:
+    """_TextAnnotation renders a colored comment line, plus a plain variant."""
+    buffer = StringIO()
+    _TextAnnotation("hello", color="").write(buffer)
+    assert buffer.getvalue() == "# hello\n"
+
+    colored = StringIO()
+    _TextAnnotation("hi").write(colored)
+    out = colored.getvalue()
+    assert "# hi" in out
+    assert out.endswith("\n")
+
+
+def test_text_annotation_satisfies_protocol() -> None:
+    """_TextAnnotation is recognized as an _Annotation via the runtime protocol."""
+    assert isinstance(_TextAnnotation("x"), _Annotation)
+
+
+async def test_annotate_source_uses_callback_per_operation(
+    hierarchical_coreai_program: AIProgram,
+) -> None:
+    """_annotate_source invokes the callback for each operation and writes output."""
+    seen_ops: list[Operation] = []
+
+    def annotate(operation: Operation) -> _Annotation:
+        seen_ops.append(operation)
+        return _TextAnnotation(f"op={operation.name}")
+
+    buffer = StringIO()
+    _annotate_source(hierarchical_coreai_program, annotate, buffer)
+
+    # Callback should have been invoked for at least one operation.
+    assert len(seen_ops) > 0, "Expected the callback to be invoked for operations"
+
+    output = buffer.getvalue()
+    assert len(output) > 0, "Expected annotated source output"
+    # The dominant source file header should be written.
+    assert "# ===" in output, "Expected a source file header in the output"
+    # Annotations produced by the callback should appear in the output.
+    assert "op=" in output, "Expected callback annotations in the output"
+
+
+async def test_annotate_source_skips_none_annotations(
+    hierarchical_coreai_program: AIProgram,
+) -> None:
+    """Operations for which the callback returns None are not annotated."""
+    buffer = StringIO()
+    _annotate_source(
+        hierarchical_coreai_program,
+        lambda _operation: None,
+        buffer,
+    )
+
+    output = buffer.getvalue()
+    # With no annotations attributed, the function reports no valid locations.
+    assert "No valid locations found" in output
+
+
+async def test_annotate_source_exclude_filters_everything(
+    hierarchical_coreai_program: AIProgram,
+) -> None:
+    """A custom exclude that drops all locations yields no annotated file."""
+    buffer = StringIO()
+    _annotate_source(
+        hierarchical_coreai_program,
+        lambda operation: _TextAnnotation(operation.name),
+        buffer,
+        exclude=lambda _location: True,
+    )
+
+    output = buffer.getvalue()
+    assert "No valid locations found" in output
+
+
+async def test_source_annotator_get_annotation_unknown_location(
+    hierarchical_coreai_program: AIProgram,
+) -> None:
+    """get_annotation returns an empty list for unattributed locations."""
+    operations = _walk_operations(hierarchical_coreai_program)
+    annotator = _SourceAnnotator(
+        operations,
+        lambda operation: _TextAnnotation(operation.name),
+    )
+
+    assert annotator.get_annotation("/does/not/exist.py", 1) == []


### PR DESCRIPTION
Annotating a program means answering, per operation, "which source line is this, and what do I want to say about it". That splits into concerns worth owning separately: walking every operation including composite bodies, rendering a value as a table or a comment line, and placing a rendered annotation against a source line.

Each becomes its own module -- utils and annotations, alongside the existing table_writer -- with source_annotator composing them into a listing of a Python file carrying per-operation information.

Styling is expressed as rich style names rather than ANSI escapes, so colour is applied for a terminal and dropped for a file or in-memory stream. Writing the escapes unconditionally put them in the text of every saved listing, which a terminal renders and an editor shows as noise. No escape codes are written by hand anywhere in the package now, and an annotation is indented to match the line it describes rather than breaking at column zero.
