### PR TITLE
add sphinx_llm for copying pages to clipboard

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,14 +14,8 @@ copyright = "2026, Apple Inc."
 extensions = [
     "myst_nb",
     "sphinx.ext.autodoc",
+    "sphinx_llm.txt",
 ]
-
-try:
-    import sphinx_llm  # noqa: F401
-
-    extensions.append("sphinx_llm.txt")
-except ImportError:
-    pass
 
 # MyST settings
 myst_enable_extensions = [
@@ -46,6 +40,7 @@ pygments_style = "friendly"
 
 # llms.txt / per-page Markdown generation (powers the "Copy page" / "View as
 # Markdown" affordance in the copy-page-button override).
+# Reference: https://github.com/NVIDIA/sphinx-llm
 llms_txt_description = "coreai-torch converts PyTorch models (torch.export ExportedProgram) to Core AI format."
 llms_txt_build_parallel = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
     "nbmake>=1.5.0",
     "ghp-import>=2.1.0",
     "nest-asyncio>=1.5.0",
+    "sphinx-llm==0.3.0",
 ]
 dev = [
     "deptry>=0.20",
@@ -123,7 +124,7 @@ exclude = ["venv", ".venv", ".direnv", ".eggs", ".git", "setup.py", "__pycache__
 #                   — pulled by transformers/test fixtures transitively; no direct import.
 #   pytest-{randomly,rerunfailures,sugar,xdist}
 #                   — pytest plugins, auto-loaded via entry points (never imported).
-#   sphinx, shibuya, myst-nb, nbmake, nest-asyncio, ghp-import
+#   sphinx, shibuya, myst-nb, nbmake, nest-asyncio, ghp-import, sphinx-llm
 #                   — docs build infra used in docs/ (not scanned).
 #   ruff, deptry, nbstripout, pre-commit
 #                   — dev tools invoked via CLI, never imported.
@@ -142,6 +143,7 @@ DEP002 = [
     "nbmake",
     "nest-asyncio",
     "ghp-import",
+    "sphinx-llm",
     "ruff",
     "deptry",
     "nbstripout",


### PR DESCRIPTION
Fix `"Copy page"` button in the docs by declaring `sphinx-llm`


The `"Copy page"` button in the docs put GitHub Pages' 404 page on the clipboard instead of the page's Markdown. The button fetches the per-page `<basename>.html.md` that the `sphinx_llm.txt` extension emits.