### PR TITLE
Record timing per dispatch, not per operation

### DIFF
--- a/coreai_torch/debugging/annotations.py
+++ b/coreai_torch/debugging/annotations.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Protocol, TextIO, runtime_checkable
+from typing import Any, Protocol, TextIO, runtime_checkable
 
 from coreai._compiler.ir import Operation
 from rich.console import Console
@@ -104,6 +104,11 @@ class _Annotation(Protocol):
     An annotation supplies text; the listing decides the comment marker and the
     indentation, so the same annotation reads correctly above Python source and
     beside a line of printed Core AI.
+
+    :meth:`lines` renders for a reader, :meth:`data` returns the same annotation as
+    plain values. Both exist because a consumer that formats its own output -- an
+    editor decorating a line, say -- needs the values rather than a string it would
+    have to parse back.
     """
 
     def lines(self: Self) -> Iterable[_AnnotationLine]:
@@ -112,6 +117,17 @@ class _Annotation(Protocol):
 
         Returns:
             The lines, in display order.
+
+        """
+        ...
+
+    def data(self: Self) -> dict[str, Any]:
+        """
+        Return this annotation as plain values, ready to serialize.
+
+        Returns:
+            The annotation's fields. Presentation (styles, comment markers) is not
+            included; only what the annotation is about.
 
         """
         ...
@@ -136,6 +152,17 @@ class _TextAnnotation:
 
         """
         return (_AnnotationLine(self.text, self.color),)
+
+    def data(self: Self) -> dict[str, Any]:
+        """
+        Return the annotation's text.
+
+        Returns:
+            ``{"text": <text>}``. A plain text annotation has nothing structured
+            behind it; one that does should carry its own fields.
+
+        """
+        return {"text": self.text}
 
     def write(self: Self, output: TextIO) -> None:
         """

--- a/coreai_torch/debugging/benchmarker.py
+++ b/coreai_torch/debugging/benchmarker.py
@@ -16,12 +16,14 @@ Key components:
 - CoreAIBenchmarker: Benchmarker implementation using Core AI Runtime
 """
 
+import asyncio
+import json
 import logging
 import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -31,19 +33,35 @@ import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
 import numpy as np
 from coreai._compiler.ir import Operation, WalkResult
 from coreai.authoring import AIProgram
-from coreai.runtime import AIModel, NDArray, Profiler, SpecializationOptions
+from coreai.runtime import (
+    AIModel,
+    LogEvent,
+    NDArray,
+    Profiler,
+    SpecializationOptions,
+)
 from typing_extensions import Self
 
-from .annotations import _ANNOTATION_STYLE, _write_line
-from .debug_info import DebugInfoRecord, parse_debug_infos
-from .source_annotator import _read_source_file, _should_exclude_location
-from .utils import LocationInfo, get_operation_locations
+from .annotations import _Annotation, _AnnotationCallback, _AnnotationLine
+from .debug_info import (
+    DebugInfoRecord,
+    _build_compile_id_to_coreai_map,
+    _build_delegate_op_to_source_map,
+    get_operation_id,
+    parse_debug_infos,
+)
+from .source_annotator import _annotate_operations
+from .table_writer import (
+    _Column,
+    _Row,
+    _TableSpec,
+    _TreeNode,
+    _write_table,
+    _write_tree,
+)
+from .utils import LocationInfo, get_operation_locations, split_module_frame
 
 logger = logging.getLogger(__name__)
-
-# Constants
-_MAX_OP_NAME_LENGTH = 58
-_TRUNCATED_OP_NAME_LENGTH = 55
 
 
 def _get_default_excluded_operations() -> tuple[str, ...]:
@@ -185,145 +203,141 @@ class Measurement:
         )
 
 
-def _group_operations_by_line(
-    module_timing: "ModuleTiming",
-    file_path: Path,
-) -> dict[int, list[tuple[Operation, "OperationTiming"]]]:
+@dataclass(frozen=True)
+class _TimingAnnotation:
     """
-    Group operations by line number for a specific file.
+    A dispatch's timing as an :class:`_Annotation`.
 
-    Args:
-        module_timing: ModuleTiming to get operations from
-        file_path: Path to match operations against
-
-    Returns:
-        Dictionary mapping line numbers to lists of (operation, timing) tuples
-
+    Carries the numbers rather than a formatted string, so a consumer that renders
+    its own output gets them from :meth:`data` instead of parsing text back.
     """
-    line_timings: dict[int, list[tuple[Operation, OperationTiming]]] = defaultdict(
-        list,
-    )
 
-    for operation, timing in module_timing.get_all_operations():
-        locations = get_operation_locations(operation)
+    op_ids: tuple[int, ...]
+    """Core AI operation IDs the dispatch covered."""
 
-        for loc in locations:
-            # Match by filename (handle both absolute and relative paths)
-            if Path(loc.filename).name == file_path.name or loc.filename == str(
-                file_path,
-            ):
-                line_timings[loc.line].append((operation, timing))
+    op_names: tuple[str, ...]
+    """Names of those operations."""
 
-    return line_timings
+    median_ms: float
+    """Median duration of the dispatch, in milliseconds."""
 
+    average_ms: float
+    """Mean duration of the dispatch, in milliseconds."""
 
-def _annotate_source_file(
-    module_timing: "ModuleTiming",
-    file_path: Path | str,
-    output: TextIO,
-) -> None:
-    """
-    Annotate a source file with timing information from a module.
+    samples: int
+    """How many measurements the statistics are over."""
 
-    Reads the source file, finds operations from that file in the module, and
-    writes the annotated source with a timing comment before each annotated line.
+    def lines(self: Self) -> "tuple[_AnnotationLine, ...]":
+        """
+        Return this timing as a single line.
 
-    The comment is styled by name rather than by escape code, so colour is applied
-    for a terminal and dropped for a file or in-memory stream. Writing the escapes
-    unconditionally left them in the text of every saved listing, which a terminal
-    renders and an editor shows as noise.
+        Returns:
+            One :class:`_AnnotationLine` naming the operations and their timing.
 
-    Args:
-        module_timing: ModuleTiming to get operation timings from
-        file_path: Path to the source file to annotate
-        output: Text stream to write annotated source to (file or stdout)
+        """
+        fused = "+".join(self.op_names) or "unknown"
+        return (
+            _AnnotationLine(
+                f"{fused}: {self.average_ms:.3f}ms (med: {self.median_ms:.3f}ms)",
+                style="",
+            ),
+        )
 
-    """
-    file_path = Path(file_path)
+    def data(self: Self) -> dict[str, Any]:
+        """
+        Return the timing as plain values.
 
-    # Read the source file
-    source_lines = _read_source_file(file_path, output)
-    if source_lines is None:
-        return
+        Returns:
+            The op ids and names the duration covers, and the duration itself. The
+            ids matter as much as the numbers: the duration belongs to the whole
+            dispatch, so a consumer must not add it up per operation.
 
-    # Group operations by line number
-    line_timings = _group_operations_by_line(module_timing, file_path)
-
-    # Annotate and write source lines
-    for line_num, line_content in enumerate(source_lines, start=1):
-        # Write timing annotation BEFORE the source line if present
-        if line_num in line_timings:
-            # Collect timing info for this line
-            timings_for_line = []
-            for operation, timing in line_timings[line_num]:
-                if timing.measurement.statistics:
-                    stats = timing.measurement.statistics
-                    timings_for_line.append(
-                        f"{operation.name}: {stats.average:.3f}ms (med: {stats.median:.3f}ms)",
-                    )
-
-            if timings_for_line:
-                # Indent the comment to match the line it describes, so the
-                # annotated listing stays readable as Python.
-                margin = line_content[: len(line_content) - len(line_content.lstrip())]
-                annotation = margin + "# " + ", ".join(timings_for_line)
-                _write_line(output, annotation, _ANNOTATION_STYLE)
-
-        # Write the original source line
-        output.write(line_content)
+        """
+        return {
+            "op_ids": list(self.op_ids),
+            "op_names": list(self.op_names),
+            "median_ms": self.median_ms,
+            "average_ms": self.average_ms,
+            "samples": self.samples,
+        }
 
 
 @dataclass
 class OperationTiming:
-    """Timing information for a single operation."""
+    """
+    Timing information for a fused group of operations.
 
-    op_id: int
-    """Operation ID from compile identifiers."""
+    The runtime profiler measures a compile identifier -- a possibly-fused group of
+    Core AI ops -- as a whole. The recorded ``measurement`` is the timing of that
+    whole group, and ``op_ids`` lists every Core AI op it contains.
+    """
+
+    op_ids: list[int]
+    """Core AI operation IDs that make up this fused group."""
+
+    operations: list[Operation]
+    """The Core AI operations that make up this fused group.
+
+    A view into the module the ``AIProgram`` owns, so it is valid only while that
+    program is alive; extract what is needed rather than stashing the result."""
 
     measurement: Measurement
     """Measurement containing statistics and timing samples in milliseconds."""
 
-    def write_to(
-        self,
-        output: TextIO,
-        operation: Operation | None = None,
-        prefix: str = "",
-    ) -> None:
+    @property
+    def op_id(self) -> int:
+        """Representative (first) operation ID of the group."""
+        return self.op_ids[0]
+
+    @property
+    def op_names(self) -> list[str]:
+        """Names of the Core AI operations in this group."""
+        return [op.name for op in self.operations]
+
+    def to_row(self: Self) -> _Row:
         """
-        Write operation timing to output.
+        Return this dispatch's cells for the summary table.
 
-        Args:
-            output: Text stream to write to
-            operation: Optional operation object for getting name and ID
-            prefix: Prefix string for indentation (default: "")
+        Every Core AI op id it covers is listed, not a representative: those
+        collide -- four rows read "121" on one model -- leaving rows that measured
+        different work indistinguishable. The ids and names fold within their
+        columns, so a wide fused group stays fully described.
+
+        Returns:
+            The :class:`_Row` describing this dispatch.
 
         """
-        # Get operation name and ID
-        if operation:
-            op_name = operation.name
-            op_id_obj = _mlir.get_operation_id(operation.location, "coreai")  # type: ignore[attr-defined]
-            op_id = getattr(op_id_obj, "value", "N/A") if op_id_obj else "N/A"
-        else:
-            op_name = "unknown"
-            op_id = self.op_id
-
-        # Truncate long operation names
-        if len(op_name) > _MAX_OP_NAME_LENGTH:
-            op_name = op_name[:_TRUNCATED_OP_NAME_LENGTH] + "..."
-
-        # Format and write statistics
-        if self.measurement.statistics:
-            stats = self.measurement.statistics
-            output.write(
-                f"{prefix}{op_id!s:<10} {op_name:<60} "
-                f"{stats.median:<12.6f} {stats.average:<12.6f} "
-                f"{stats.minimum:<12.6f} {stats.maximum:<12.6f} {stats.std_dev:<12.6f}\n",
+        statistics = self.measurement.statistics
+        numbers = (
+            (
+                f"{statistics.median:.6f}",
+                f"{statistics.average:.6f}",
+                f"{statistics.minimum:.6f}",
+                f"{statistics.maximum:.6f}",
+                f"{statistics.std_dev:.6f}",
             )
-        else:
-            output.write(
-                f"{prefix}{op_id!s:<10} {op_name:<60} "
-                f"{'N/A':<12} {'N/A':<12} {'N/A':<12} {'N/A':<12} {'N/A':<12}\n",
-            )
+            if statistics is not None
+            else ("N/A",) * 5
+        )
+        return _Row(
+            cells=(
+                ", ".join(str(op_id) for op_id in self.op_ids),
+                "\n".join(self.op_names) or "unknown",
+                *numbers,
+            ),
+        )
+
+    @property
+    def tree_label(self: Self) -> str:
+        """One line naming this dispatch's operations and its timing."""
+        fused = "+".join(self.op_names) or "unknown"
+        statistics = self.measurement.statistics
+        if statistics is None:
+            return f"{fused}: no timing data"
+        return (
+            f"{fused}: med {statistics.median:.6f}ms, avg {statistics.average:.6f}ms, "
+            f"min {statistics.minimum:.6f}ms, max {statistics.maximum:.6f}ms"
+        )
 
 
 @dataclass
@@ -335,54 +349,56 @@ class ModuleTiming:
     """
 
     name: str
-    """Module name."""
+    """Module name as the stack trace gives it, instance number included:
+    ``Linear$3``. Also the key :meth:`BenchmarkResult.get_module_timings` files this
+    module under, so it identifies the instance rather than the type."""
 
-    operation_timings: list[tuple[Operation, OperationTiming]]
-    """List of (operation, timing) tuples for operations in this module."""
+    operation_timings: list[OperationTiming]
+    """Operation timings (one per fused group) belonging to this module."""
 
     children: list["ModuleTiming"]
     """Child modules."""
 
     @property
-    def aggregated_op_stats(self) -> Statistics | None:
+    def type_name(self: Self) -> str:
         """
-        Get aggregated operation statistics for this module (including children).
-
-        Collects all samples from operations in this module and its children,
-        then computes statistics on the combined samples. The resulting statistics
-        represent the distribution of per-operation timings, not per-iteration totals.
+        The module's type, without the instance number.
 
         Returns:
-            Statistics object with aggregated per-operation timing or None if no samples
+            ``"Linear"`` for ``Linear$3``, and the whole name when it carries no
+            instance number.
 
         """
-        # Collect all samples from this module and all children efficiently
-        all_samples = []
-        for _, timing in self.get_all_operations():
-            all_samples.extend(timing.measurement.samples)
-
-        # Return statistics from all collected samples
-        return Statistics.from_values(all_samples)
+        return split_module_frame(self.name)[0]
 
     @property
-    def total_time(self) -> Statistics | None:
+    def instance(self: Self) -> int | None:
         """
-        Get total time statistics for this module.
-
-        This is an alias for aggregated_op_stats for backward compatibility.
+        Which instance of :attr:`type_name` this module is.
 
         Returns:
-            Statistics object with aggregated per-operation timing or None if no samples
+            ``3`` for ``Linear$3``. None when the name carries no instance number,
+            as ``<unknown>`` does.
 
         """
-        return self.aggregated_op_stats
+        return split_module_frame(self.name)[1]
 
-    def get_all_operations(self: Self) -> list[tuple[Operation, OperationTiming]]:
+    # A module deliberately reports no total. Fusion crosses module boundaries --
+    # 86% of dispatches in a 3-layer MLP and 93% in a transformer block cover more
+    # than one module -- and a dispatch is attributed whole to the module of its
+    # first member, so a total charges one module for a sibling's work and leaves
+    # the sibling reading 0.000ms. A LayerNorm fused into its neighbour is not free,
+    # and saying so was worse than saying nothing.
+    #
+    # :meth:`get_all_operations` still exposes the dispatches, so a caller that
+    # knows a group spans modules can aggregate on its own terms.
+
+    def get_all_operations(self: Self) -> list[OperationTiming]:
         """
-        Get all operations in this module and its children recursively.
+        Get all operation timings in this module and its children recursively.
 
         Returns:
-            List of all (operation, timing) tuples
+            List of all OperationTiming objects
 
         """
         all_ops = list(self.operation_timings)
@@ -406,37 +422,83 @@ class ModuleTiming:
     def get_operations_at_location(
         self: Self,
         location: LocationInfo,
-    ) -> list[tuple[Operation, OperationTiming]]:
+    ) -> list[OperationTiming]:
         """
-        Find operations at a specific source location.
+        Find operation timings at a specific source location.
 
-        Searches this module and all children recursively for operations
-        that have the given file/line/col location.
+        Searches this module and all children recursively for timing groups any of
+        whose operations have the given file/line/col location.
 
         Args:
             location: LocationInfo to search for
 
         Returns:
-            List of (operation, timing) tuples matching the location
+            List of OperationTiming objects matching the location
 
         """
         matching_ops = []
 
-        # Search all operations in this module and children
-        for operation, timing in self.get_all_operations():
-            op_locations = get_operation_locations(operation)
-
-            # Check if any of the operation's locations match
-            for op_loc in op_locations:
-                if (
-                    op_loc.filename == location.filename
-                    and op_loc.line == location.line
-                    and op_loc.col == location.col
-                ):
-                    matching_ops.append((operation, timing))
-                    break  # Don't add the same operation twice
+        # Search all operation timings in this module and children
+        for timing in self.get_all_operations():
+            matched = False
+            for operation in timing.operations:
+                for op_loc in get_operation_locations(operation):
+                    if (
+                        op_loc.filename == location.filename
+                        and op_loc.line == location.line
+                        and op_loc.col == location.col
+                    ):
+                        matching_ops.append(timing)
+                        matched = True
+                        break
+                if matched:
+                    break  # Don't add the same timing twice
 
         return matching_ops
+
+    def _annotation_callback(self: Self) -> _AnnotationCallback:
+        """
+        Build the callback describing each operation's timing.
+
+        A group's timing is reported once, on its representative operation. Other
+        members return ``None`` and are skipped: the runtime measured the group as a
+        whole, so there is no per-member figure to give, and annotating each one
+        repeated a single measurement as many times as the group had members --
+        several identical comments stacked above one source line.
+
+        Returns:
+            A callback mapping an operation to its annotation, or ``None`` for an
+            operation this module did not time, or that a group already covers.
+
+        """
+        timing_by_representative: dict[int, OperationTiming] = {
+            timing.op_id: timing for timing in self.get_all_operations()
+        }
+
+        def annotate(operation: Operation) -> _Annotation | None:
+            operation_id = get_operation_id(operation)
+            if operation_id is None:
+                return None
+
+            # Only the representative carries the group's timing; other members of
+            # the same group are covered by it and skipped.
+            timing = timing_by_representative.get(operation_id)
+            if timing is None:
+                return None
+
+            statistics = timing.measurement.statistics
+            if statistics is None:
+                return None
+
+            return _TimingAnnotation(
+                op_ids=tuple(timing.op_ids),
+                op_names=tuple(timing.op_names),
+                median_ms=statistics.median,
+                average_ms=statistics.average,
+                samples=len(timing.measurement.samples),
+            )
+
+        return annotate
 
     def annotate_dominant_source(
         self: Self,
@@ -446,9 +508,10 @@ class ModuleTiming:
         """
         Find the dominant source file and annotate it with timing information.
 
-        Uses operations only from this module (not children). For each operation,
-        gets file/line/col locations, filters them, and takes the last valid file.
-        The dominant file is the one that appears most frequently.
+        Uses operations from this module and its children, and renders through the
+        shared source annotator, so styling follows the destination stream -- colour
+        for a terminal, plain text for a file -- and each comment is indented to
+        match the line it describes.
 
         Args:
             output: Text stream to write annotated source to (file or stdout)
@@ -456,80 +519,72 @@ class ModuleTiming:
                     which excludes torch files, exported_program.py, and "-"
 
         """
-        # Use default exclusion if not provided
-        if exclude is None:
-            exclude = _should_exclude_location
+        operations = [
+            operation
+            for timing in self.get_all_operations()
+            for operation in timing.operations
+        ]
+        _annotate_operations(
+            operations,
+            self._annotation_callback(),
+            output,
+            exclude=exclude,
+        )
 
-        # Count occurrences of each source file from locations
-        file_counts: dict[str, int] = defaultdict(int)
-        # Only use operations from this module, not children
-        for operation, _ in self.operation_timings:
-            # Get file/line/col locations
-            locations = get_operation_locations(operation)
+    def to_tree_node(self: Self, show_operations: bool = False) -> _TreeNode:
+        """
+        Build this module's node, with its children beneath it.
 
-            if locations:
-                # Take the last file (innermost)
-                last_loc = locations[-1]
+        Args:
+            show_operations: Whether to list each dispatch under its module
+                (default: False)
 
-                # Check if it should be excluded
-                if not exclude(last_loc):
-                    last_file = last_loc.filename
+        Returns:
+            The :class:`_TreeNode` for this module.
 
-                    # Only count if file exists
-                    if Path(last_file).exists():
-                        file_counts[last_file] += 1
+        """
+        # A count, not a duration: see the note above :meth:`get_all_operations`.
+        node = _TreeNode(
+            label=(
+                f"{self.name} ({len(self.operation_timings)} "
+                f"dispatch{'es' if len(self.operation_timings) != 1 else ''})"
+                if self.operation_timings
+                else self.name
+            )
+        )
 
-        if not file_counts:
-            output.write("# No valid locations found in operations\n")
-            return
+        if show_operations:
+            for timing in self.operation_timings:
+                node.add(timing.tree_label)
 
-        # Find the most common file (dominant)
-        dominant_file = max(file_counts.items(), key=lambda x: x[1])[0]
+        for child in self.children:
+            node.add(child.to_tree_node(show_operations=show_operations))
 
-        # Annotate the dominant file
-        _annotate_source_file(self, dominant_file, output)
+        return node
 
     def write_to(
         self: Self,
         output: TextIO,
-        indent: int = 0,
         show_operations: bool = False,
+        *,
+        width: int | None = None,
     ) -> None:
         """
-        Write module timing to output.
+        Write this module and its children to output as a tree.
+
+        Rendered through the shared tree writer, so a long fused name wraps within
+        the width its depth leaves rather than being truncated.
 
         Args:
             output: Text stream to write to
-            indent: Indentation level (default: 0)
-            show_operations: Whether to show individual operations (default: False)
+            show_operations: Whether to list each dispatch (default: False)
+            width: Console width to render at. Defaults to
+                :data:`~coreai_torch.debugging.table_writer._DEFAULT_WIDTH`.
 
         """
-        prefix = "  " * indent
-
-        # Module header with statistics
-        stats = self.aggregated_op_stats
-        if stats:
-            output.write(
-                f"{prefix}- {self.name} "
-                f"[Avg: {stats.average:.3f}ms, "
-                f"Median: {stats.median:.3f}ms, "
-                f"Min: {stats.minimum:.3f}ms, "
-                f"Max: {stats.maximum:.3f}ms]\n",
-            )
-        else:
-            output.write(f"{prefix}- {self.name} [No timing data]\n")
-
-        # Show operations if requested
-        if show_operations and self.operation_timings:
-            for operation, timing in self.operation_timings:
-                # Use the timing's write_to method with proper indentation
-                timing.write_to(output, operation, prefix + "  - ")
-        elif self.operation_timings:
-            output.write(f"{prefix}  ({len(self.operation_timings)} operations)\n")
-
-        # Recursively write children
-        for child in self.children:
-            child.write_to(output, indent + 1, show_operations)
+        _write_tree(
+            self.to_tree_node(show_operations=show_operations), output, width=width
+        )
 
 
 @dataclass
@@ -540,113 +595,116 @@ class BenchmarkResult:
     Contains timing information for each operation, organized by operation ID.
     """
 
-    operation_timings: list[tuple[Operation, OperationTiming]]
+    operation_timings: list[OperationTiming]
     """
-    List of (operation, timing) tuples for each profiled operation.
+    List of operation timings, one per profiled fused group of operations.
     """
 
-    total_duration_ns: int
-    """Total execution time in nanoseconds."""
+    operations_by_id: dict[int, Operation] = field(default_factory=dict)
+    """
+    Every Core AI operation in the benchmarked function, by id -- including those no
+    dispatch reported.
 
-    def get_average_timing(self: Self, op_id: int) -> float | None:
+    The denominator for coverage, and which operations count is the caller's
+    judgement: constants and layout operations such as ``pad`` or ``broadcast_to``
+    fold into a consumer's addressing and never become GPU work, so counting them
+    understates coverage badly. An operation absent from every
+    :attr:`OperationTiming.op_ids` was not timed, and its location says where in the
+    source it came from.
+    """
+
+    # No per-operation lookup is offered. A dispatch's duration belongs to every
+    # operation in it, so returning that duration for one op id -- which
+    # `get_average_timing` and `get_measurement` used to do -- reads as the cost of
+    # that operation, and summing over ops then multiplies the real cost by each
+    # group's width. A caller who wants the dispatch an operation landed in can find
+    # it, and sees `op_ids` when they do:
+    #
+    #     op_id = get_operation_id(operation)
+    #     timing = next(
+    #         (t for t in result.operation_timings if op_id in t.op_ids), None
+    #     )
+
+    def get_operation_summary(self: Self) -> list[OperationTiming]:
         """
-        Get average execution time for an operation in milliseconds.
-
-        Args:
-            op_id: Operation ID to get timing for
+        Get operation timings sorted by median duration.
 
         Returns:
-            Average duration in milliseconds, or None if no measurements exist
+            List of OperationTiming sorted by median duration (descending)
 
         """
-        for _, timing in self.operation_timings:
-            if timing.op_id == op_id:
-                if timing.measurement.statistics:
-                    return timing.measurement.statistics.average
-                return None
-        return None
-
-    def get_measurement(self: Self, op_id: int) -> Measurement | None:
-        """
-        Get measurement for an operation.
-
-        Args:
-            op_id: Operation ID to get measurement for
-
-        Returns:
-            Measurement object or None if no measurements exist
-
-        """
-        for _, timing in self.operation_timings:
-            if timing.op_id == op_id:
-                return timing.measurement
-        return None
-
-    def get_operation_summary(self: Self) -> list[tuple[Operation, Measurement]]:
-        """
-        Get summary of operation timings sorted by median duration.
-
-        Returns:
-            List of (operation, measurement) tuples sorted by median duration (descending)
-
-        """
-        summary = [(op, timing.measurement) for op, timing in self.operation_timings]
+        summary = list(self.operation_timings)
 
         # Sort by median duration (descending)
-        summary.sort(key=lambda x: x[1].sort_key, reverse=True)
+        summary.sort(key=lambda timing: timing.measurement.sort_key, reverse=True)
         return summary
 
     def get_module_timings(self) -> dict[str, ModuleTiming]:
         """
-        Group operation timings by modules based on stack traces.
+        Group dispatches by module, from their operations' stack traces.
 
-        Creates a hierarchical tree structure where each level in the stack trace
-        becomes a nested module.
+        Each stack-trace frame becomes a nested module. A dispatch is filed against
+        the deepest module containing *every* operation it covers, so a dispatch
+        listed under a module is wholly inside it. Filing it against its first
+        member's module instead charged one module for a sibling's work -- and fusion
+        crosses module boundaries in most dispatches, so that was the common case,
+        not the exception.
+
+        Modules appear even when no dispatch is filed against them, which is the
+        honest reading of a module whose work always fuses with a sibling's: the
+        structure is there, and nothing is attributed to it alone.
 
         Returns:
             Dictionary mapping module names to ModuleTiming objects at the top level
 
         """
-        # Build module tree structure
         root_modules: dict[str, ModuleTiming] = {}
 
-        for operation, timing in self.operation_timings:
-            # Get stack trace from operation location
-            stack_trace = _mlir.get_stack_trace(operation.location)  # type: ignore[attr-defined]
-
-            # Treat operations without stack traces as belonging to "<unknown>" module
-            if not stack_trace:
-                stack_trace = ["<unknown>"]
-
-            # Build hierarchy from stack trace (outermost to innermost)
-            # The stack trace is already reversed, so first entry is outermost
-            current_level = root_modules
-            parent_module = None
-
-            for frame in stack_trace:
-                # Find or create module at this level
-                if frame not in current_level:
-                    new_module = ModuleTiming(
-                        name=frame,
-                        operation_timings=[],
-                        children=[],
+        def module_at(path: tuple[str, ...]) -> ModuleTiming | None:
+            """Find or create the module at *path*, creating ancestors as needed."""
+            level = root_modules
+            module: ModuleTiming | None = None
+            for frame in path:
+                if frame not in level:
+                    created = ModuleTiming(
+                        name=frame, operation_timings=[], children=[]
                     )
-                    current_level[frame] = new_module
+                    level[frame] = created
+                    if module is not None:
+                        module.children.append(created)
+                module = level[frame]
+                level = {child.name: child for child in module.children}
+            return module
 
-                    # Add to parent's children list if this isn't a root module
-                    if parent_module is not None:
-                        parent_module.children.append(new_module)
+        for timing in self.operation_timings:
+            paths = [
+                tuple(
+                    _mlir.get_stack_trace(operation.location)  # type: ignore[attr-defined]
+                    or ("<unknown>",)
+                )
+                for operation in timing.operations
+            ]
+            if not paths:
+                continue
 
-                parent_module = current_level[frame]
+            # Every member's module exists in the tree, so the hierarchy is complete
+            # whether or not a dispatch is filed against a given module.
+            for path in paths:
+                module_at(path)
 
-                # Move to next level (children)
-                # Build a dict from children for easy lookup
-                children_dict = {child.name: child for child in parent_module.children}
-                current_level = children_dict
+            # The deepest module common to all members contains the whole dispatch.
+            common = paths[0]
+            for path in paths[1:]:
+                limit = min(len(common), len(path))
+                index = 0
+                while index < limit and common[index] == path[index]:
+                    index += 1
+                common = common[:index]
 
-            # Add operation to the deepest (innermost) module
-            if parent_module is not None:
-                parent_module.operation_timings.append((operation, timing))
+            # Members spanning different roots are contained by no module.
+            owner = module_at(common or ("<unknown>",))
+            if owner is not None:
+                owner.operation_timings.append(timing)
 
         return root_modules
 
@@ -654,53 +712,253 @@ class BenchmarkResult:
         self: Self,
         output: TextIO,
         top_n: int | None = None,
+        *,
+        width: int | None = None,
     ) -> None:
         """
         Write benchmark results summary to output.
 
+        One row per dispatch, since that is what the runtime measured: the duration
+        belongs to the listed operations jointly, not to any one of them.
+
         Args:
             output: Text stream to write to
-            top_n: If specified, only show top N slowest operations
+            top_n: If specified, only show top N slowest dispatches
+            width: Console width to render at. Defaults to
+                :data:`~coreai_torch.debugging.table_writer._DEFAULT_WIDTH`.
 
         """
         summary = self.get_operation_summary()
         if top_n is not None:
             summary = summary[:top_n]
 
-        output.write("=" * 150 + "\n")
-        output.write("Benchmark Results\n")
-        output.write("=" * 150 + "\n")
-        output.write(f"Total execution time: {self.total_duration_ns / 1e9:.3f} s\n")
-        output.write(f"Total operations profiled: {len(self.operation_timings)}\n")
-        output.write("\n")
-        output.write("Per-operation timing (sorted by median duration):\n")
-        output.write("-" * 150 + "\n")
-        output.write(
-            f"{'Op ID':<10} {'Operation':<60} {'Median (ms)':<12} "
-            f"{'Avg (ms)':<12} {'Min (ms)':<12} {'Max (ms)':<12} {'StdDev (ms)':<12}\n",
+        spec = _TableSpec(
+            title="Benchmark Results",
+            columns=(
+                _Column("Core AI op ids"),
+                _Column("Operations"),
+                _Column("Median (ms)", justify="right"),
+                _Column("Avg (ms)", justify="right"),
+                _Column("Min (ms)", justify="right"),
+                _Column("Max (ms)", justify="right"),
+                _Column("StdDev (ms)", justify="right"),
+            ),
+            caption=(
+                f"{len(self.operation_timings)} dispatches profiled. A row's duration "
+                f"covers every operation listed in it."
+            ),
+            # Ids and names fold within their columns, so rule between rows to keep
+            # it clear where a wide fused group ends.
+            show_lines=True,
         )
-        output.write("-" * 150 + "\n")
+        for timing in summary:
+            spec.add(timing)
 
-        for operation, measurement in summary:
-            # Find the timing for this operation to use its write_to method
-            timing = None
-            for _, t in self.operation_timings:
-                if t.measurement == measurement:
-                    timing = t
-                    break
+        _write_table(spec, output, width=width)
 
-            if timing:
-                timing.write_to(output, operation)
-            else:
-                # Fallback if timing not found (shouldn't happen)
-                op_name = operation.name if operation else "unknown"
-                op_id = "N/A"
-                output.write(
-                    f"{op_id!s:<10} {op_name:<60} "
-                    f"{'N/A':<12} {'N/A':<12} {'N/A':<12} {'N/A':<12} {'N/A':<12}\n",
-                )
 
-        output.write("=" * 150 + "\n")
+@dataclass(frozen=True)
+class EventData:
+    """Structured representation of a profiler log event's encoded data."""
+
+    @dataclass(frozen=True)
+    class Interval:
+        """Timing interval information for an event."""
+
+        duration: int
+        """Duration of the interval (in nanoseconds)."""
+
+        @staticmethod
+        def from_dict(data: dict[str, Any]) -> "EventData.Interval":
+            """
+            Create an Interval instance from a parsed JSON dictionary.
+
+            Args:
+                data: Parsed JSON dictionary, e.g. ``{"duration": 1667}``
+
+            Returns:
+                Interval instance populated from the dictionary
+
+            """
+            return EventData.Interval(duration=data["duration"])
+
+    interval: "EventData.Interval | None" = None
+    """Interval timing information for the event, if present."""
+
+    @dataclass(frozen=True)
+    class CompileIdGroup:
+        """The operations a fused dispatch was built from.
+
+        The runtime emits one of these alongside the interval for a dispatch that
+        fused several operations, keyed on the same compile identifiers, so the
+        group's membership is stated rather than inferred.
+
+        ``members`` are ids in the delegate's own numbering, not Core AI ids, so they
+        need translating before they name anything in the converted program.
+        """
+
+        group_id: int
+        """Identifier the runtime assigned this dispatch, equal to the event's
+        ``delegate_id``. Assigned per dispatch, so it is meaningful only within the
+        run that reported it."""
+
+        members: tuple[int, ...]
+        """Operation ids fused into this dispatch, in the order reported."""
+
+        @staticmethod
+        def from_dict(data: dict[str, Any]) -> "EventData.CompileIdGroup":
+            """
+            Create a CompileIdGroup from a parsed JSON dictionary.
+
+            Args:
+                data: Parsed JSON dictionary, e.g.
+                    ``{"groupId": 4294967296, "members": [153, 154]}``
+
+            Returns:
+                CompileIdGroup instance populated from the dictionary
+
+            """
+            return EventData.CompileIdGroup(
+                group_id=data["groupId"],
+                members=tuple(data.get("members", ())),
+            )
+
+    compile_id_group: "EventData.CompileIdGroup | None" = None
+    """Fused-dispatch membership for the event, if present."""
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "EventData":
+        """
+        Create an EventData instance from a parsed JSON dictionary.
+
+        The payload is a tagged union: an event carries an ``interval``, a
+        ``compileIdGroup``, or neither.
+
+        Args:
+            data: Parsed JSON dictionary, e.g. ``{"interval": {"duration": 1667}}``
+                or ``{"compileIdGroup": {"groupId": 1, "members": [2, 3]}}``
+
+        Returns:
+            EventData instance populated from the dictionary
+
+        """
+        interval_data = data.get("interval")
+        group_data = data.get("compileIdGroup")
+        return EventData(
+            interval=(
+                EventData.Interval.from_dict(interval_data) if interval_data else None
+            ),
+            compile_id_group=(
+                EventData.CompileIdGroup.from_dict(group_data) if group_data else None
+            ),
+        )
+
+
+def _event_payload(event: LogEvent) -> bytes | str | None:
+    """
+    The event's encoded payload as JSON, if this runtime exposes one.
+
+    Only ``encoded_data`` carries JSON. The neighbouring ``data`` field is a
+    rendering for people, so parsing it yields nothing and is not attempted; a
+    runtime without ``encoded_data`` reports no payload at all.
+
+    Args:
+        event: LogEvent from the profiler.
+
+    Returns:
+        The payload, or ``None`` if the event exposes none.
+
+    """
+    return getattr(event, "encoded_data", None) or None
+
+
+_GPU_INTERVAL_PREFIX = "GPU "
+_HARDWARE_MARKER = " HW "
+
+
+def _is_gpu_interval(event: LogEvent) -> bool:
+    """
+    Whether this event times one GPU encoder.
+
+    Labelled ``GPU HW CB:0, Enc:3`` or ``GPU Host CB:0, Enc:3``. Activity codes, memory
+    intervals and fused-op-group membership are not per-encoder measurements, so they
+    must not be counted as timing this tool failed to recognise.
+
+    Args:
+        event: LogEvent from the profiler.
+
+    Returns:
+        True when the event measures a GPU encoder.
+
+    """
+    return event.event_id.startswith(_GPU_INTERVAL_PREFIX)
+
+
+def _is_hardware_timestamped(event: LogEvent) -> bool:
+    """
+    Whether a GPU interval was measured by the GPU's own counters.
+
+    Every encoder is reported twice, once from the GPU counters and once from the host
+    clock. The host figure includes queueing and does not answer how long the operation
+    took on the GPU, and both carry the same compile identifiers -- so recording both
+    pools two different measurements into one sample list, where a median falls between
+    them and a dispatch's samples run from near zero to the real duration.
+
+    Args:
+        event: LogEvent from the profiler.
+
+    Returns:
+        True when the interval came from the GPU counters.
+
+    """
+    return _HARDWARE_MARKER in event.event_id
+
+
+def _parse_event_data(event_data: bytes | str | None) -> EventData:
+    """
+    Parse a log event's encoded data into a structured EventData object.
+
+    The runtime hands this field over in more than one shape: JSON, as bytes or as
+    str, and a placeholder such as ``"empty()"`` for an event carrying no payload.
+    Anything unrecognised yields an EventData with no interval, so a caller simply
+    finds nothing to attribute.
+
+    Never raises. It runs inside a profiler callback invoked from a runtime thread,
+    where an exception has nowhere to go and can take the process down with it.
+
+    Args:
+        event_data: The event's ``data`` field.
+
+    Returns:
+        EventData parsed from the payload, or an empty one if it holds no JSON
+        object.
+
+    """
+    if not event_data:
+        return EventData()
+
+    if isinstance(event_data, bytes | bytearray):
+        try:
+            event_data = event_data.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.debug("Profiler event data is not valid UTF-8; ignoring it")
+            return EventData()
+
+    try:
+        parsed = json.loads(event_data)
+    except (TypeError, ValueError):
+        # Placeholders such as "empty()" are expected, not an error.
+        logger.debug("Profiler event data is not JSON (%r); ignoring it", event_data)
+        return EventData()
+
+    if not isinstance(parsed, dict):
+        return EventData()
+
+    try:
+        return EventData.from_dict(parsed)
+    except (KeyError, TypeError):
+        logger.debug("Profiler event data lacks an interval duration; ignoring it")
+        return EventData()
 
 
 class Benchmarker(ABC):
@@ -732,14 +990,33 @@ class Benchmarker(ABC):
         self.excluded_operations = excluded_operations or ()
         self.specialization_options = specialization_options
         self._intervals: dict[int, tuple[int, Any]] = {}
-        self._timings: dict[int, list[float]] = defaultdict(list)
+        # Keyed by ``(odix_id, sorted Core AI op ids)``, holding the dispatch's full
+        # undivided duration once per run. Sorted because a delegate reports members
+        # in a varying order, which otherwise splits one dispatch across entries.
+        # ``delegate_id`` cannot key this: for a fused dispatch it is a per-dispatch
+        # counter, so nothing would accumulate.
+        self._timings: dict[tuple[int, tuple[int, ...]], list[float]] = defaultdict(
+            list
+        )
         self._interval_counter = 0
-        self._total_start: int | None = None
-        self._total_end: int | None = None
         self._debug_info_records: list[DebugInfoRecord] = []
-        self._odix_to_coreai_map: dict[int, list[int]] = {}
+        # Maps a compiled op identifier (odix_id, delegate_id) to the list of
+        # coreai op IDs fused into it. Keyed on the same pair carried by a runtime
+        # ``CompileIdentifiers`` object, so timing is attributed without collapsing
+        # distinct delegate dispatches together.
+        self._compile_id_to_coreai_map: dict[tuple[int, int | None], list[int]] = {}
+        # Translates the operation ids a delegate reports into Core AI op ids, so a
+        # dispatch it describes at run time can extend the map above.
+        self._delegate_op_to_coreai_map: dict[int, list[int]] = {}
+        # Durations whose compile identifier is not resolved yet: a delegate reports
+        # a dispatch's timing before describing its membership.
+        self._pending_durations: dict[tuple[int, int | None], list[float]] = (
+            defaultdict(list)
+        )
         self._coreai_operations: dict[int, Operation] = {}
-        self._lock = threading.Lock()
+        # A Condition rather than a Lock so the benchmark coroutine can wait for the
+        # runtime's asynchronous callbacks to settle; otherwise used as a plain Lock.
+        self._lock = threading.Condition()
         self._state = _BenchmarkerState.LOADING
 
     def _extract_coreai_operations(self: Self) -> None:
@@ -760,48 +1037,221 @@ class Benchmarker(ABC):
 
         self.coreai_program._mlir_module.operation.walk(walk_operations)
 
-    def _build_odix_to_coreai_map(self: Self) -> None:
+    def _build_compile_id_to_coreai_map(self: Self) -> None:
         """
-        Build a mapping from ODIX IDs to Core AI operation IDs for fast lookup.
+        Build the mappings that turn compile identifiers into Core AI operation IDs.
 
-        A single ODIX ID can map to multiple Core AI IDs, so we store a list.
-        This should be called once after loading debug_infos.
+        Two are needed, because timing arrives keyed two different ways:
+
+        * ``(odix_id, delegate_id) -> [coreai ids]``, for identifiers the debug info
+          describes statically. A single compiled op may fuse several Core AI ops, so
+          each value is a list.
+        * ``delegate op id -> [coreai ids]``, used to translate the membership a
+          delegate reports for a dispatch whose identifier it assigned at run time.
+
+        Called once after loading debug_infos.
         """
-        self._odix_to_coreai_map.clear()
+        self._compile_id_to_coreai_map = _build_compile_id_to_coreai_map(
+            self._debug_info_records,
+        )
+        self._delegate_op_to_coreai_map = _build_delegate_op_to_source_map(
+            self._debug_info_records,
+        )
 
-        for record in self._debug_info_records:
-            for debug_info in record.operations:
-                odix_id = debug_info.odix_id
-                coreai_id = debug_info.get_op_id("coreai")
-
-                if coreai_id is not None and isinstance(coreai_id, int):
-                    if odix_id not in self._odix_to_coreai_map:
-                        self._odix_to_coreai_map[odix_id] = []
-                    self._odix_to_coreai_map[odix_id].append(coreai_id)
-
-    def _get_coreai_op_ids(self: Self, odix_id: int) -> list[int]:
+    def _get_coreai_op_ids(
+        self: Self,
+        odix_id: int,
+        delegate_id: int | None,
+    ) -> list[int]:
         """
-        Convert ODIX ID from compile_ids to list of Core AI operation IDs using debug_infos.
+        Convert compile identifiers to a list of Core AI operation IDs.
 
         Args:
-            odix_id: ODIX ID from compile_ids.id
+            odix_id: ODIX ID from ``compile_ids.id``
+            delegate_id: Delegate ID from ``compile_ids.delegate_id`` (may be None)
 
         Returns:
             List of Core AI operation IDs if found, otherwise empty list
 
         """
-        return self._odix_to_coreai_map.get(odix_id, [])
+        return self._compile_id_to_coreai_map.get((odix_id, delegate_id), [])
 
     def _reset_state(self: Self) -> None:
         """Reset internal state before a new benchmark run."""
         with self._lock:
             self._intervals.clear()
             self._timings.clear()
+            self._pending_durations.clear()
             self._interval_counter = 0
-            self._total_start = None
-            self._total_end = None
 
-    def _on_log_event_begin(self: Self, event: Any) -> int:
+    def _wait_for_intervals_to_complete(self: Self, timeout_s: float = 10.0) -> None:
+        """
+        Block until every started interval has received its matching end event.
+
+        Callbacks arrive asynchronously, so when ``await function(...)`` returns some
+        intervals may be open. Reaching ``COMPLETED`` first makes their end events hit
+        the ``state != RUNNING`` guard, dropping samples and varying the reported op
+        set between runs. :meth:`_on_log_event_end` wakes this waiter when the last
+        interval closes.
+
+        Call while still ``RUNNING``, via :func:`asyncio.to_thread` so the event loop
+        is not blocked.
+
+        Args:
+            timeout_s: Hard upper bound on the wait.
+
+        """
+        with self._lock:
+            settled = self._lock.wait_for(
+                lambda: not self._intervals,
+                timeout=timeout_s,
+            )
+            if not settled:
+                logger.warning(
+                    "Timed out after %.1fs waiting for %d profiler interval(s) "
+                    "to complete; results may be incomplete",
+                    timeout_s,
+                    len(self._intervals),
+                )
+
+    def _record_dispatch_duration(
+        self: Self,
+        compile_ids: Any,
+        duration_ms: float,
+    ) -> None:
+        """
+        Attribute one measured duration to the dispatch it belongs to.
+
+        Recorded once for the whole dispatch, never divided across the operations it
+        fused: a division reported a fraction of the real cost for each of them.
+        An identifier the delegate assigned at run time is not in the static map and
+        its membership is described only afterwards, so the duration waits in
+        :attr:`_pending_durations` for :meth:`_resolve_compile_id_group` to flush it.
+
+        Caller holds :attr:`_lock`.
+
+        Args:
+            compile_ids: The event's ``CompileIdentifiers``.
+            duration_ms: Measured duration in milliseconds.
+
+        """
+        key = (compile_ids.id, compile_ids.delegate_id)
+        coreai_ids = self._get_coreai_op_ids(*key)
+        if coreai_ids:
+            self._timings[(compile_ids.id, tuple(sorted(coreai_ids)))].append(
+                duration_ms
+            )
+        else:
+            self._pending_durations[key].append(duration_ms)
+
+    def _resolve_compile_id_group(
+        self: Self,
+        compile_ids: Any,
+        group: "EventData.CompileIdGroup",
+    ) -> None:
+        """
+        Learn a dispatch's operations, and attribute whatever was waiting on it.
+
+        Membership comes in the delegate's own numbering, so it is translated to
+        Core AI ids and added to the map static attribution uses -- one place
+        resolves a compile identifier, however it was described.
+
+        Caller holds :attr:`_lock`.
+
+        Args:
+            compile_ids: The event's ``CompileIdentifiers``.
+            group: Membership the delegate reported for this dispatch.
+
+        """
+        key = (compile_ids.id, compile_ids.delegate_id)
+
+        coreai_ids: list[int] = []
+        unresolved: set[int] = set()
+        for member in group.members:
+            mapped = self._delegate_op_to_coreai_map.get(member)
+            if not mapped:
+                unresolved.add(member)
+                continue
+            for coreai_id in mapped:
+                if coreai_id not in coreai_ids:
+                    coreai_ids.append(coreai_id)
+
+        if unresolved:
+            # Members absent from the debug info are attributed to nothing, so name
+            # them rather than quietly reporting a smaller group. Which ids they are
+            # is what says whether attribution is incomplete or the members simply
+            # have no Core AI counterpart, as constants and memref views do not.
+            logger.debug(
+                "Dispatch (odix=%s, delegate=%s): %d of %d reported operations are "
+                "absent from the debug info and are not attributed: %s",
+                key[0],
+                key[1],
+                len(unresolved),
+                len(group.members),
+                sorted(unresolved),
+            )
+
+        pending = self._pending_durations.pop(key, [])
+        if not coreai_ids:
+            if pending:
+                logger.warning(
+                    "No Core AI operations resolved for compile id "
+                    "(odix=%s, delegate=%s), dropping %d timing sample(s)",
+                    key[0],
+                    key[1],
+                    len(pending),
+                )
+            return
+
+        self._compile_id_to_coreai_map[key] = coreai_ids
+        self._timings[(compile_ids.id, tuple(sorted(coreai_ids)))].extend(pending)
+
+    def _on_log_event(self: Self, event: LogEvent) -> None:
+        """
+        Handle a self-contained profiler log event.
+
+        Unlike the begin/end interval callbacks, this event carries its own payload:
+        either a duration, attributed as in :meth:`_on_log_event_end`, or the
+        membership of a fused dispatch, recorded in :attr:`compile_id_groups`.
+
+        Args:
+            event: LogEvent from the profiler
+
+        """
+        # Only process events when actively running benchmark
+        if self._state != _BenchmarkerState.RUNNING:
+            return
+
+        # Only process inference phase events
+        phase = _LogEventPhase(event.phase)
+        if phase != _LogEventPhase.INFERENCE:
+            return
+
+        event_data = _parse_event_data(event_data=_event_payload(event))
+
+        if event_data.compile_id_group is not None:
+            with self._lock:
+                self._resolve_compile_id_group(
+                    event.compile_ids, event_data.compile_id_group
+                )
+            return
+
+        # Without interval timing there is nothing to attribute.
+        if event_data.interval is None:
+            return
+
+        # A GPU encoder first, then which clock measured it. Only the hardware
+        # measurement answers how long the operation took on the GPU.
+        if not (_is_gpu_interval(event) and _is_hardware_timestamped(event)):
+            return
+
+        with self._lock:
+            self._record_dispatch_duration(
+                event.compile_ids,
+                float(event_data.interval.duration) / 1e6,
+            )
+
+    def _on_log_event_begin(self: Self, event: LogEvent) -> int:
         """
         Handle profiler interval begin events.
 
@@ -823,6 +1273,12 @@ class Benchmarker(ABC):
         if phase != _LogEventPhase.INFERENCE:
             return 0  # Return dummy interval_id for non-inference events
 
+        # Opening an interval for the host-timestamped twin would pool it with the
+        # hardware measurement of the same encoder; its end event then finds no open
+        # interval and is ignored.
+        if _is_gpu_interval(event) and not _is_hardware_timestamped(event):
+            return 0
+
         with self._lock:
             interval_id = self._interval_counter
             self._interval_counter += 1
@@ -833,13 +1289,9 @@ class Benchmarker(ABC):
                 event.compile_ids,
             )
 
-            # Track total execution time
-            if self._total_start is None:
-                self._total_start = event.timestamp
-
             return interval_id
 
-    def _on_log_event_end(self: Self, event: Any, interval_id: int) -> None:
+    def _on_log_event_end(self: Self, event: LogEvent, interval_id: int) -> None:
         """
         Handle profiler interval end events.
 
@@ -864,34 +1316,17 @@ class Benchmarker(ABC):
                 # Event was not stored or already processed
                 return
 
-            start_time, compile_ids = start_info
+            start_time, _ = start_info
 
-            # Calculate duration in milliseconds
+            # Calculate duration in milliseconds and attribute it to the group
             duration_ns = event.timestamp - start_time
-            duration_ms = float(duration_ns) / 1e6
+            self._record_dispatch_duration(event.compile_ids, float(duration_ns) / 1e6)
 
-            # Convert ODIX ID to Core AI IDs (there may be multiple)
-            odix_id = compile_ids.id
-            coreai_ids = self._get_coreai_op_ids(odix_id)
-
-            # If we have Core AI IDs, distribute timing equally (mean) to all of them
-            if coreai_ids:
-                # Divide timing equally among all Core AI operations
-                mean_duration_ms = duration_ms / len(coreai_ids)
-                for coreai_id in coreai_ids:
-                    self._timings[coreai_id].append(mean_duration_ms)
-            else:
-                # No Core AI ID mapping found - log warning and skip storing
-                logger.warning(
-                    "No Core AI ID mapping found for ODIX ID %d, skipping timing sample",
-                    odix_id,
-                )
-
-            # Track total execution time
-            self._total_end = event.timestamp
-
-            # Clean up interval
+            # Waking the waiter once the last interval closes is what lets the
+            # benchmark reach COMPLETED without dropping late samples.
             self._intervals.pop(interval_id)
+            if not self._intervals:
+                self._lock.notify_all()
 
     def _create_result(self: Self) -> BenchmarkResult:
         """
@@ -902,31 +1337,74 @@ class Benchmarker(ABC):
 
         """
         with self._lock:
-            total_duration = (
-                self._total_end - self._total_start
-                if self._total_start and self._total_end
-                else 0
-            )
-
-            # Convert raw timings to list of (operation, _OperationTiming) tuples
-            # Filter out excluded operations
+            # Convert raw timings to a list of OperationTiming, one per set of Core
+            # AI ops measured together as a single dispatch.
             operation_timings_list = []
-            for op_id, samples in self._timings.items():
-                operation = self._coreai_operations.get(op_id)
-                if operation is not None:
-                    # Skip excluded operations
-                    if operation.name in self.excluded_operations:
+            for (_odix_id, group_ids), samples in self._timings.items():
+                # Resolve each group member to its MLIR operation, dropping
+                # excluded ops (e.g. coreai.graph / coreai.constant).
+                group_ops: list[Operation] = []
+                group_op_ids: list[int] = []
+                for op_id in group_ids:
+                    operation = self._coreai_operations.get(op_id)
+                    if operation is None or operation.name in self.excluded_operations:
                         continue
+                    group_ops.append(operation)
+                    group_op_ids.append(op_id)
 
-                    timing = OperationTiming(
-                        op_id=op_id,
+                # Skip groups whose members were all unknown or excluded.
+                if not group_ops:
+                    continue
+
+                operation_timings_list.append(
+                    OperationTiming(
+                        op_ids=group_op_ids,
+                        operations=group_ops,
                         measurement=Measurement.from_samples(samples),
                     )
-                    operation_timings_list.append((operation, timing))
+                )
+
+            # Durations whose description never arrived. Most measure a whole
+            # function or delegate region -- a "symbol" in the debug info -- and are
+            # excluded from per-op timing by design. The rest name no dispatch at
+            # all, because an interval does not always carry a delegate_id.
+            if self._pending_durations:
+                symbol_odix_ids = {
+                    operation.odix_id
+                    for record in self._debug_info_records
+                    for operation in record.operations
+                    if operation.is_symbol()
+                }
+                symbols = {
+                    compile_id: durations
+                    for compile_id, durations in self._pending_durations.items()
+                    if compile_id[0] in symbol_odix_ids
+                }
+                unnamed = {
+                    compile_id: durations
+                    for compile_id, durations in self._pending_durations.items()
+                    if compile_id[0] not in symbol_odix_ids
+                }
+                if symbols:
+                    logger.debug(
+                        "%d sample(s) measure a whole function or delegate region "
+                        "rather than an operation, and are excluded from per-op "
+                        "timing: %s",
+                        sum(len(d) for d in symbols.values()),
+                        sorted(symbols, key=str),
+                    )
+                if unnamed:
+                    logger.warning(
+                        "%d timing sample(s) across %d compile identifier(s) were "
+                        "measured but could not be attributed to any operation: %s",
+                        sum(len(d) for d in unnamed.values()),
+                        len(unnamed),
+                        sorted(unnamed, key=str),
+                    )
 
             return BenchmarkResult(
                 operation_timings=operation_timings_list,
-                total_duration_ns=total_duration,
+                operations_by_id=dict(self._coreai_operations),
             )
 
     @abstractmethod
@@ -940,7 +1418,9 @@ class Benchmarker(ABC):
 
         Args:
             inputs: Dictionary mapping input names to tensor values
-            num_runs: Number of times to run the benchmark (default: 1)
+            num_runs: Number of timed iterations (default: 1). Always preceded by an
+                untimed warmup run, which is not one of them, so the samples describe
+                the steady state rather than first-inference costs.
 
         Returns:
             BenchmarkResult containing timing information for all operations
@@ -962,7 +1442,9 @@ class CoreAIBenchmarker(Benchmarker):
 
         Args:
             inputs: Dictionary mapping input names to tensor values
-            num_runs: Number of times to run the benchmark (default: 1)
+            num_runs: Number of timed iterations (default: 1). Always preceded by an
+                untimed warmup run, which is not one of them, so the samples describe
+                the steady state rather than first-inference costs.
 
         Returns:
             BenchmarkResult containing timing information
@@ -990,13 +1472,14 @@ class CoreAIBenchmarker(Benchmarker):
             # Extract Core AI operations from module
             self._extract_coreai_operations()
 
-            # Build ODIX to Core AI ID mapping for fast lookup
-            self._build_odix_to_coreai_map()
+            # Build compile-id to Core AI ID mapping for fast lookup
+            self._build_compile_id_to_coreai_map()
 
             # Create profiler with callbacks
             profiler = Profiler(
                 on_log_event_begin=self._on_log_event_begin,
                 on_log_event_end=self._on_log_event_end,
+                on_log_event=self._on_log_event,
             )
 
             # Load function with profiler
@@ -1019,6 +1502,18 @@ class CoreAIBenchmarker(Benchmarker):
                 num_runs,
             )
 
+            # A first inference pays costs the steady state does not, and nothing
+            # filters it out -- it dominated the mean, three orders of magnitude
+            # above the median. Run one iteration before collection starts, so the
+            # state guard discards its events.
+            #
+            # Unconditional, and not one of the `num_runs`: exempting `num_runs=1`
+            # made the cheapest way to ask for a measurement the one way to get a
+            # cold one, so a single-run number was not comparable with any other --
+            # including the other side of a `timing_diff` comparison.
+            logger.debug("Warmup run (untimed)")
+            await function(nd_inputs)
+
             # Transition to RUNNING state to start collecting timing data
             self._state = _BenchmarkerState.RUNNING
 
@@ -1026,16 +1521,14 @@ class CoreAIBenchmarker(Benchmarker):
                 logger.debug("Benchmark run %d/%d", i + 1, num_runs)
                 await function(nd_inputs)
 
-            # Transition to COMPLETED state to stop collecting timing data
-            self._state = _BenchmarkerState.COMPLETED
+            # Callbacks arrive asynchronously, so intervals from the final runs may
+            # still be open. Block (off the event loop) until they close: flipping to
+            # COMPLETED first drops late end events, and the reported op set then
+            # varies between identical runs.
+            await asyncio.to_thread(self._wait_for_intervals_to_complete)
 
-            # Ensure all profiler callbacks have completed before creating result
-            # The runtime should ensure callback completion after function execution,
-            # but we add explicit synchronization to be safe
-            with self._lock:
-                # At this point, all function executions are complete, and this lock
-                # ensures any remaining callback processing is finished
-                pass
+            # All intervals have closed; stop collecting and build the result.
+            self._state = _BenchmarkerState.COMPLETED
 
             result = self._create_result()
             logger.info(

--- a/coreai_torch/debugging/debug_info.py
+++ b/coreai_torch/debugging/debug_info.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, TextIO
 
 import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
@@ -32,6 +33,37 @@ from .table_writer import _Column, _Row, _TableSpec, _write_table
 # Stand-in filename for a location that carries only an operation id, with no real
 # source position behind it. Left out of a rendered summary.
 _OP_ID_PSEUDO_FILE = "op_id"
+
+
+class _Delegate(Enum):
+    """Enumerates the compute delegates an operation may be dispatched to."""
+
+    BNNS = "BNNS"
+    MPS = "MPS"
+    FALLBACK = "FALLBACK"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def from_string(cls, identifier: str) -> "_Delegate":
+        """Create a :class:`_Delegate` from its string representation.
+
+        Args:
+            identifier: The delegate identifier.
+
+        Returns:
+            The matching :class:`_Delegate` member, or
+            :attr:`_Delegate.UNKNOWN` if the string does not start with any
+            known delegate prefix.
+        """
+        identifier = identifier.lower()
+        if identifier.startswith("bnns"):
+            return cls.BNNS
+        elif identifier.startswith("mps"):
+            return cls.MPS
+        elif identifier.startswith("odix"):
+            return cls.FALLBACK
+        else:
+            return cls.UNKNOWN
 
 
 @dataclass
@@ -263,6 +295,12 @@ def _format_metadata_value(value: Metadata.Value) -> str:
 class DebugInfo:
     """Represents debug information for a single operation."""
 
+    class SymbolType(str, Enum):
+        """Enumerates the kinds of symbols carried in "symbol" metadata."""
+
+        FUNCTION = "function"
+        DELEGATE = "delegate"
+
     odix_id: int
     name: str
     source_locations: tuple[SourceLocation, ...]
@@ -344,6 +382,84 @@ class DebugInfo:
                 ids.append(value_field)
 
         return ids
+
+    def get_symbol_names(self, symbol_type: "DebugInfo.SymbolType") -> list[str]:
+        """
+        Get all symbol names for a given symbol type.
+
+        Collects every "symbol" metadata entry whose "type" field matches
+        *symbol_type* and returns the corresponding "value" fields. Mirrors the
+        "op_id" metadata structure, but the symbol name is a string carried in the
+        "value" field rather than an integer.
+
+        Args:
+            symbol_type: Symbol type, either
+                :attr:`DebugInfo.SymbolType.FUNCTION` or
+                :attr:`DebugInfo.SymbolType.DELEGATE`.
+
+        Returns:
+            List of symbol names matching the given type.
+
+        """
+        names: list[str] = []
+        for metadata in self.metadatas:
+            if metadata.key != "symbol":
+                continue
+
+            if metadata.value.value_type != "dictionary" or not isinstance(
+                metadata.value.value,
+                dict,
+            ):
+                continue
+
+            type_field = self._get_str_field(metadata.value.value, "type")
+            if type_field != symbol_type.value:
+                continue
+
+            name_field = self._get_str_field(metadata.value.value, "value")
+            if name_field is not None:
+                names.append(name_field)
+
+        return names
+
+    def get_symbol_name(self, symbol_type: "DebugInfo.SymbolType") -> str | None:
+        """
+        Get the symbol name for a given symbol type.
+
+        Format: metadata with key "symbol" containing dictionary
+        ``{"type": "<function|delegate>", "value": <name>}``. Mirrors the
+        :meth:`get_op_id` structure but returns the string symbol name carried in
+        the "value" field.
+
+        Args:
+            symbol_type: Symbol type, either
+                :attr:`DebugInfo.SymbolType.FUNCTION` or
+                :attr:`DebugInfo.SymbolType.DELEGATE`.
+
+        Returns:
+            Symbol name if present, None otherwise.
+
+        """
+        symbol_names = self.get_symbol_names(symbol_type=symbol_type)
+        return symbol_names[0] if len(symbol_names) > 0 else None
+
+    def is_symbol(self) -> bool:
+        """
+        Whether this operation represents a symbol rather than a real op.
+
+        Returns ``True`` if the operation carries a ``"symbol"`` metadata entry of
+        any :class:`DebugInfo.SymbolType` (``function`` or ``delegate``). Such
+        entries are structural markers rather than directly schedulable Core AI
+        operations.
+
+        Returns:
+            ``True`` if a function or delegate symbol is present, else ``False``.
+
+        """
+        return any(
+            self.get_symbol_name(symbol_type) is not None
+            for symbol_type in DebugInfo.SymbolType
+        )
 
     def get_source(self) -> str | None:
         """Get source identifier if present."""
@@ -624,6 +740,11 @@ class DebugInfoRecord:
     identifier: str
     operations: tuple[DebugInfo, ...]
 
+    @property
+    def is_fallback(self) -> bool:
+        """Whether this is a fallback record per :class:`_Delegate`."""
+        return _Delegate.from_string(self.identifier) == _Delegate.FALLBACK
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DebugInfoRecord":
         """Parse from dictionary."""
@@ -812,6 +933,193 @@ def parse_debug_infos(debug_infos_bytes: bytes) -> list[DebugInfoRecord]:
     debug_infos_data = json.loads(debug_infos_str)
 
     return [DebugInfoRecord.from_dict(item) for item in debug_infos_data]
+
+
+def _build_source_to_odix_map(
+    debug_info_records: list[DebugInfoRecord],
+    source_level: str,
+) -> dict[int, int]:
+    """
+    Build a mapping from source op ID to odix ID from fallback debug info records.
+
+    Iterates over the fallback (``"odix"``) records and extracts the source-level
+    op ID and the odix ID from each operation.
+
+    Symbol entries are included deliberately. This map answers "which odix id owns
+    this source op", not "what should be timed" -- and on the GPU path the symbol
+    entries are the only operations carrying source ids at all, so excluding them
+    leaves the map empty and every timing sample unattributable. Timing still never
+    lands on a symbol: :func:`_build_compile_id_to_coreai_map` skips them when it
+    forms groups.
+
+    Args:
+        debug_info_records: Parsed debug information containing operation mappings.
+        source_level: Dialect level to extract source op IDs from (e.g.
+            ``"coreai"``).
+
+    Returns:
+        Dictionary mapping source_op_id to odix_id.
+
+    """
+    source_to_odix: dict[int, int] = {}
+    for record in debug_info_records:
+        if not record.is_fallback:
+            continue
+        for op in record.operations:
+            for source_id in op.get_op_ids(source_level):
+                existing_odix_id = source_to_odix.get(source_id)
+                if existing_odix_id is None or existing_odix_id < op.odix_id:
+                    source_to_odix[source_id] = op.odix_id
+    return source_to_odix
+
+
+def _record_op_id_level(identifier: str) -> str | None:
+    """
+    The dialect level a record numbers its own operations in.
+
+    A record is named ``"<level>_op_id"``, so the level is what remains once that
+    suffix is removed -- ``"odix_op_id"`` numbers ``"odix"``, and a delegate record
+    numbers whatever level its own name gives.
+
+    Note the suffix is stripped rather than the name split on its first underscore:
+    a level whose name itself contains an underscore would otherwise be truncated to
+    its first word, silently selecting a different level's numbering.
+
+    Args:
+        identifier: Record identifier.
+
+    Returns:
+        The level name, or ``None`` if the identifier is not of that form.
+
+    """
+    suffix = "_op_id"
+    if not identifier.endswith(suffix) or len(identifier) == len(suffix):
+        return None
+    return identifier[: -len(suffix)]
+
+
+def _build_delegate_op_to_source_map(
+    debug_info_records: list[DebugInfoRecord],
+    source_level: str = "coreai",
+) -> dict[int, list[int]]:
+    """
+    Build a ``delegate op id -> [source op ids]`` map from the delegate records.
+
+    A delegate reports the operations in a fused dispatch using its own numbering,
+    not the source level's, so timing attributed to those ids has to be translated
+    before it names anything in the converted program. Each delegate record carries
+    both, one per operation, which is what makes the translation possible.
+
+    Args:
+        debug_info_records: Parsed debug information.
+        source_level: Dialect level to translate into (defaults to ``"coreai"``).
+
+    Returns:
+        Dictionary mapping a delegate's operation id to source-level op ids.
+
+    """
+    result: dict[int, list[int]] = {}
+    for record in debug_info_records:
+        # Fallback records number their ops in the same space the runtime reports
+        # directly, so they need no translation.
+        if record.is_fallback:
+            continue
+        level = _record_op_id_level(record.identifier)
+        if level is None:
+            continue
+        for op in record.operations:
+            # Symbols mark a function or delegate rather than schedulable work.
+            if op.is_symbol():
+                continue
+            source_ids = op.get_op_ids(source_level)
+            if not source_ids:
+                continue
+            for delegate_id in op.get_op_ids(level):
+                mapped = result.setdefault(delegate_id, [])
+                for source_id in source_ids:
+                    if source_id not in mapped:
+                        mapped.append(source_id)
+    return result
+
+
+def _build_compile_id_to_coreai_map(
+    debug_info_records: list[DebugInfoRecord],
+    source_level: str = "coreai",
+) -> dict[tuple[int, int | None], list[int]]:
+    """
+    Build a ``(odix_id, delegate_id) -> [source op ids]`` map for the profiler.
+
+    The runtime reports timing both for delegate dispatches (carrying a
+    ``delegate_id``) and for fallback-run ops (``delegate_id`` is ``None``).
+    Delegate records are processed first so each delegate op forms its own
+    per-dispatch group, keyed ``(resolved_odix_id, op.odix_id)`` where the first
+    component comes from :func:`_build_source_to_odix_map`. Fallback records then
+    cover any remaining source ops not handled by a delegate, keyed
+    ``(op.odix_id, None)``. Values are de-duplicated in first-seen order.
+
+    Args:
+        debug_info_records: Parsed debug information.
+        source_level: Dialect level for the op IDs (defaults to ``"coreai"``).
+
+    Returns:
+        Dictionary mapping ``(odix_id, delegate_id)`` to source-level op IDs.
+
+    """
+    source_to_odix_map = _build_source_to_odix_map(debug_info_records, source_level)
+    result: dict[tuple[int, int | None], list[int]] = {}
+    # Source ops already attributed to a delegate dispatch; fallback records only
+    # cover the remaining ops.
+    claimed: set[int] = set()
+
+    # Pass 1: delegate records, one per-dispatch group each.
+    for record in debug_info_records:
+        if record.is_fallback:
+            continue
+        for op in record.operations:
+            delegate_id = op.odix_id
+            for coreai_id in op.get_op_ids(source_level):
+                odix_id = source_to_odix_map.get(coreai_id)
+                if odix_id is None or coreai_id in claimed:
+                    continue
+                coreai_ids = result.setdefault((odix_id, delegate_id), [])
+                if coreai_id not in coreai_ids:
+                    coreai_ids.append(coreai_id)
+                claimed.add(coreai_id)
+
+    # Pass 2: fallback records cover the remaining ops.
+    for record in debug_info_records:
+        if not record.is_fallback:
+            continue
+        for op in record.operations:
+            # Skip symbol ops; they are structural markers, not real ops.
+            if op.is_symbol():
+                continue
+            for coreai_id in op.get_op_ids(source_level):
+                if coreai_id in claimed:
+                    continue
+                coreai_ids = result.setdefault((op.odix_id, None), [])
+                if coreai_id not in coreai_ids:
+                    coreai_ids.append(coreai_id)
+
+    return result
+
+
+def get_operation_id(operation: Operation, level: str = "coreai") -> int | None:
+    """
+    Extract an operation ID from an operation's location.
+
+    Args:
+        operation: Operation whose location carries the operation ID.
+        level: Dialect level to extract the ID for (defaults to ``"coreai"``).
+
+    Returns:
+        The operation ID for *level*, or ``None`` if no ID is present.
+
+    """
+    op_id_obj = _mlir.get_operation_id(operation.location, level)
+    if op_id_obj is None:
+        return None
+    return getattr(op_id_obj, "value", None)
 
 
 def _build_coreai_op_map(program: AIProgram) -> dict[int, "Operation"]:

--- a/coreai_torch/debugging/graph_diff.py
+++ b/coreai_torch/debugging/graph_diff.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import re
 import sys
-from dataclasses import dataclass, fields
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from io import StringIO
 from typing import Any, TextIO
@@ -26,7 +27,9 @@ import torch
 from coreai._compiler.ir import Block, Operation, Region, Value
 from coreai.authoring import AIProgram
 
+from .debug_info import get_operation_id
 from .graph_match import (
+    _OP_NODE,
     Label,
     WeightPolicy,
     align,
@@ -40,7 +43,10 @@ from .table_writer import _Column, _Row, _TableSpec, _write_table
 # ---------------------------------------------------------------------------
 
 _CALLEE_SYMBOL_RE = re.compile(r"<@([^>]+)>")
-_UUID_SUFFIX_RE = re.compile(r"_[0-9a-f]{8,}$")
+# `coreai.graph`'s deferred-construction path draws this from `string.ascii_lowercase`
+# only, never digits -- see `_composite_label`'s docstring. Matched here only as a
+# fallback for a composite whose `template_op` attribute is unavailable.
+_UUID_SUFFIX_RE = re.compile(r"_[a-z]{8,}$")
 
 
 class OpDiffType(Enum):
@@ -242,6 +248,13 @@ class GraphDiff:
         summary: Summary statistics
         source_graph: Source NetworkX graph with IR references in nodes
         target_graph: Target NetworkX graph with IR references in nodes
+        weights: The `WeightPolicy` this diff was computed under. `write_diff` reads
+            it back to label a modified pair's *reason* under the same policy that
+            decided the pair was not identical -- `node_labels` defaults to `IGNORE`,
+            and a reason computed under a different policy than the one that rejected
+            the pair can describe the wrong thing: an IGNORE-computed label elides a
+            parameter's value, so a DIGEST-only difference is invisible to it and the
+            true reason (`attributes: ...`) is never reached.
 
     Lifetime: the two graphs hold `ir_object` references owned by the programs they
     were built from, and comparison reads them lazily. A `GraphDiff` is therefore
@@ -261,6 +274,7 @@ class GraphDiff:
     summary: GraphDiffSummary
     source_graph: nx.DiGraph
     target_graph: nx.DiGraph
+    weights: WeightPolicy = WeightPolicy.IGNORE
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +414,7 @@ def compute_graph_diff(
         summary=summary,
         source_graph=source_graph,
         target_graph=target_graph,
+        weights=weights,
     )
 
 
@@ -462,6 +477,117 @@ def _collect_entry_points(module: Any) -> dict[str, Any]:
     return entry_points
 
 
+@dataclass(frozen=True)
+class OpIdAlignment:
+    """Which Core AI operation of one program became which of another."""
+
+    mapping: dict[int, int] = field(default_factory=dict)
+    """Before op id -> after op id, for operations that correspond."""
+
+    modified: set[int] = field(default_factory=set)
+    """Before ids in :attr:`mapping` whose counterpart is the same operation wired or
+    configured differently, so a difference in it may be the rewiring itself."""
+
+    removed: list[int] = field(default_factory=list)
+    """Before ids with no counterpart."""
+
+    added: list[int] = field(default_factory=list)
+    """After ids with no counterpart."""
+
+    identical: bool = False
+    """Whether the two programs are provably the same graph. Any difference measured
+    between runs of an identical program is noise, which is what makes such a pair
+    worth running deliberately."""
+
+
+def _coreai_ids(graph: nx.DiGraph) -> dict[int, int]:
+    """
+    Map each operation node of *graph* to the Core AI op id it carries.
+
+    Node ids come from a counter over the whole build -- values, regions and blocks
+    included -- so they are neither op ids nor comparable between programs. The
+    operation each op node stores is what carries the id.
+
+    Args:
+        graph: Graph built by :func:`_build_module_graph`.
+
+    Returns:
+        Node id -> Core AI op id, for operation nodes carrying one.
+
+    """
+    ids: dict[int, int] = {}
+    for node, data in graph.nodes(data=True):
+        if data.get("type") != _OP_NODE:
+            continue
+        operation = data.get("ir_object")
+        if operation is None:
+            continue
+        op_id = get_operation_id(operation)
+        if op_id is not None:
+            ids[node] = op_id
+    return ids
+
+
+def op_id_alignment(
+    before: AIProgram,
+    after: AIProgram,
+    entry_point: str = "main",
+    *,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
+) -> OpIdAlignment:
+    """
+    Which Core AI operation of *before* became which of *after*.
+
+    Core AI op ids are positional, so inserting a layer renumbers everything after
+    it. Comparing two programs by raw op id therefore compares unrelated operations,
+    and does so quietly: most ids survive an edit unchanged.
+
+    Args:
+        before: The "before" program.
+        after: The "after" program.
+        entry_point: Function to compare.
+        weights: Whether parameter *values* count towards an operation's identity.
+            Ignored by default: a rebuild re-initialises them, which would report
+            every edit as a total rewrite.
+
+    Returns:
+        The correspondence, and what it leaves over.
+
+    """
+    before_graph = _build_module_graph(before._mlir_module, entry_point)
+    after_graph = _build_module_graph(after._mlir_module, entry_point)
+    alignment = align(before_graph, after_graph, weights=weights)
+
+    before_ids = _coreai_ids(before_graph)
+    after_ids = _coreai_ids(after_graph)
+
+    mapping: dict[int, int] = {}
+    modified: set[int] = set()
+    # Exact pairs first, then modified ones: a modified pair is the same operation
+    # rewired, so it is a correspondence rather than a removal plus an addition --
+    # but which pairs those are is worth reporting.
+    for source, target in alignment.mapping.items():
+        if source in before_ids and target in after_ids:
+            mapping[before_ids[source]] = after_ids[target]
+    for source, target in alignment.modified:
+        if source in before_ids and target in after_ids:
+            mapping[before_ids[source]] = after_ids[target]
+            modified.add(before_ids[source])
+
+    return OpIdAlignment(
+        mapping=mapping,
+        modified=modified,
+        removed=sorted(
+            {before_ids[n] for n in alignment.removed if n in before_ids} - set(mapping)
+        ),
+        added=sorted(
+            {after_ids[n] for n in alignment.added if n in after_ids}
+            - set(mapping.values())
+        ),
+        identical=alignment.identical,
+    )
+
+
 def _extract_invoke_callee(graph: nx.DiGraph, node_id: int) -> str | None:
     """Extract callee symbol name from a coreai.invoke node."""
     node = graph.nodes[node_id]
@@ -479,8 +605,45 @@ def _extract_invoke_callee(graph: nx.DiGraph, node_id: int) -> str | None:
 
 
 def _strip_uuid_suffix(name: str) -> str:
-    """Strip trailing UUID suffix for display: 'sdpa_abc123ef' -> 'sdpa'."""
+    """
+    Strip trailing random suffix for display: 'sdpa_maskless_qxrbmzua' -> 'sdpa_maskless'.
+
+    A best-effort fallback for when the generating `GraphOp` carries no `template_op`
+    attribute (see `_composite_label`) -- pattern-matching a randomised suffix rather
+    than reading what named it. `coreai.graph`'s deferred-construction path draws the
+    suffix from `string.ascii_lowercase` only, 8 characters, never digits (see
+    `coreai._compiler.dialects.coreai.graph._randomize_fn_name`), which is what
+    `_UUID_SUFFIX_RE` matches. A composite created some other way, or a future
+    generator using a different alphabet, may not match; the name is then shown as
+    printed, suffix and all, rather than stripped incorrectly.
+    """
     return _UUID_SUFFIX_RE.sub("", name)
+
+
+def _composite_label(sym_name: str, entry_points: Mapping[str, Any]) -> str:
+    """
+    Human-readable name for a composite callee.
+
+    Prefers `template_op`, the pre-randomisation name the generating `GraphOp`
+    recorded verbatim alongside its randomised symbol name -- see
+    `coreai._compiler.dialects.coreai.graph._generate_fn_with_body`, which sets both
+    together. Exact and independent of the suffix's alphabet or length, unlike
+    `_strip_uuid_suffix`, which has to guess the pattern and cannot: composite names
+    are not a closed set to match against, since module externalization lets a caller
+    register one under any name it chooses.
+
+    Args:
+        sym_name: The composite's (possibly suffixed) symbol name.
+        entry_points: `sym_name -> GraphOp`, as `_collect_entry_points` returns.
+
+    Returns:
+        `template_op` when the op carries one, else `sym_name` with a
+        best-effort suffix strip.
+
+    """
+    op = entry_points.get(sym_name)
+    template_op = getattr(op, "template_op", None) if op is not None else None
+    return template_op or _strip_uuid_suffix(sym_name)
 
 
 # ---------------------------------------------------------------------------
@@ -616,10 +779,13 @@ def _describe_modification(
         return "rewired: " + ", ".join(f"operand {index}" for index in moved)
 
     # Nothing else is left. Verification rejected this pair, and it rejects only on
-    # a label mismatch or an operand mismatch; the labels here are the ones with
-    # parameter values *left out*, and the operands correspond. So the values are
-    # what differ -- which is only reachable when the diff was computed under
-    # `WeightPolicy.DIGEST`, since that is the only policy that looks at them.
+    # a label mismatch or an operand mismatch. `labels` is now computed under the
+    # diff's own policy (see `GraphDiff.weights`), so a genuine value-only
+    # difference is already caught above as an `attributes: ...` label mismatch --
+    # this fallback is a last resort for the rare case where this function's
+    # after-the-fact recomputation disagrees with `align`'s own internal check
+    # (e.g. `DIGEST_PORTABLE`, whose blob digests need `blobs=` and are not
+    # recomputed here), not the primary way a value difference gets named.
     return "parameter values differ"
 
 
@@ -674,7 +840,15 @@ def _format_unified_ops_table(
     # about one op.
     claimed_source: set[int] = set()
     claimed_target: set[int] = set()
-    labels = (node_labels(source_graph), node_labels(target_graph))
+    # Under the same policy the diff itself was computed under -- `node_labels`
+    # defaults to IGNORE, which elides a parameter's value, so a DIGEST-only
+    # difference would otherwise never reach the "attributes: ..." branch below and
+    # `_describe_modification` would report a vaguer reason for exactly the pair
+    # that policy exists to catch.
+    labels = (
+        node_labels(source_graph, diff.weights),
+        node_labels(target_graph, diff.weights),
+    )
 
     for src_node, tgt_node in diff.modified_node_pairs:
         src_id = responsible_op(source_graph, src_node)
@@ -697,9 +871,19 @@ def _format_unified_ops_table(
                 OpDiffType.MODIFIED.value,
                 source_graph.nodes[src_id].get("op_name", "unknown"),
                 target_graph.nodes[tgt_id].get("op_name", "unknown"),
+                # Described against the *responsible ops*, not the raw pair. A
+                # difference on a leaf op (a constant, no operands) often lands on
+                # its result value instead: a value's Label never carries
+                # `attributes`, so the op producing it is not what was compared and
+                # a real value change is invisible, falling through to a vaguer
+                # "rewired"/"parameter values differ" guess. The op just confirmed
+                # `_is_one_op_changed` is the same op on both sides, whether or not
+                # `align` ever paired it -- `_describe_modification`'s first check
+                # only needs the two labels, not a correspondence entry for either
+                # id, so describing the op directly is always at least as precise.
                 _describe_modification(
-                    src_node,
-                    tgt_node,
+                    src_id,
+                    tgt_id,
                     labels,
                     (source_graph, target_graph),
                     diff.source_to_target_mapping,
@@ -931,7 +1115,7 @@ def _diff_matched_composites(
         src_graph = _build_module_graph(source_module, src_callee)
         tgt_graph = _build_module_graph(target_module, tgt_callee)
         diff = compute_graph_diff(src_graph, tgt_graph, weights=weights)
-        label = _strip_uuid_suffix(src_callee)
+        label = _composite_label(src_callee, source_eps)
         results.append(
             (f"{label} (source: @{src_callee}, target: @{tgt_callee})", diff)
         )
@@ -942,6 +1126,8 @@ def _report_unmatched_composites(
     main_diff: GraphDiff,
     source_main_graph: nx.DiGraph,
     target_main_graph: nx.DiGraph,
+    source_eps: dict[str, Any],
+    target_eps: dict[str, Any],
     matched_src_callees: set[str],
     matched_tgt_callees: set[str],
 ) -> list[tuple[str, GraphDiff | None]]:
@@ -951,14 +1137,14 @@ def _report_unmatched_composites(
     for src_id in main_diff.unmapped_source_nodes:
         src_callee = _extract_invoke_callee(source_main_graph, src_id)
         if src_callee and src_callee not in matched_src_callees:
-            label = _strip_uuid_suffix(src_callee)
+            label = _composite_label(src_callee, source_eps)
             results.append((f"REMOVED composite: {label} (@{src_callee})", None))
             matched_src_callees.add(src_callee)
 
     for tgt_id in main_diff.unmapped_target_nodes:
         tgt_callee = _extract_invoke_callee(target_main_graph, tgt_id)
         if tgt_callee and tgt_callee not in matched_tgt_callees:
-            label = _strip_uuid_suffix(tgt_callee)
+            label = _composite_label(tgt_callee, target_eps)
             results.append((f"ADDED composite: {label} (@{tgt_callee})", None))
             matched_tgt_callees.add(tgt_callee)
 
@@ -979,7 +1165,7 @@ def _report_orphan_composites(
 
     for sym_name in source_eps:
         if sym_name != "main" and sym_name not in matched_src_callees:
-            label = _strip_uuid_suffix(sym_name)
+            label = _composite_label(sym_name, source_eps)
             if sym_name in target_eps:
                 src_graph = _build_module_graph(source_module, sym_name)
                 tgt_graph = _build_module_graph(target_module, sym_name)
@@ -998,7 +1184,7 @@ def _report_orphan_composites(
             and sym_name not in matched_tgt_callees
             and sym_name not in source_eps
         ):
-            label = _strip_uuid_suffix(sym_name)
+            label = _composite_label(sym_name, target_eps)
             results.append((f"ADDED composite: {label} (@{sym_name})", None))
 
     return results
@@ -1070,6 +1256,8 @@ def compute_per_graph_diff(
             main_diff,
             source_main_graph,
             target_main_graph,
+            source_eps,
+            target_eps,
             matched_src_callees,
             matched_tgt_callees,
         )

--- a/coreai_torch/debugging/source_annotator.py
+++ b/coreai_torch/debugging/source_annotator.py
@@ -9,13 +9,14 @@ Generic source annotation for Core AI operations.
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Self, TextIO
+from typing import Any, Self, TextIO
 
 import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
 from coreai._compiler.ir import Operation
@@ -28,7 +29,12 @@ from .annotations import (
     _TextAnnotation,
     _write_line,
 )
-from .utils import LocationInfo, _walk_operations, get_operation_locations
+from .utils import (
+    LocationInfo,
+    _walk_operations,
+    get_operation_locations,
+    split_module_frame,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +55,21 @@ __all__ = [
 # ("HierarchicalModel$1", "SubModel$2")). Disambiguates instances of the same
 # submodule that share a source file/line.
 ModulePath = tuple[str, ...]
+
+
+def _module_step(frame: str) -> dict[str, Any]:
+    """
+    One step of a module path, as plain values.
+
+    Args:
+        frame: Module frame, e.g. ``"Linear$3"``.
+
+    Returns:
+        The frame verbatim, plus its type and instance number.
+
+    """
+    type_name, instance = split_module_frame(frame)
+    return {"name": frame, "type_name": type_name, "instance": instance}
 
 
 @dataclass(frozen=True)
@@ -376,6 +397,54 @@ class _SourceAnnotator:
             if module is None or attributed.module == module
         ]
 
+    def annotation_data(self: Self, filename: str | Path) -> list[dict[str, Any]]:
+        """
+        Every annotation in a file as plain values, ready to serialize.
+
+        One call per file rather than per line, so a consumer that decorates source
+        -- an editor, say -- gets the whole file's annotations without walking it.
+
+        Args:
+            filename: Source file to describe.
+
+        Returns:
+            One entry per annotation, each holding its 1-based ``line``, the
+            ``module`` instance path it was attributed to, and the annotation's own
+            fields from :meth:`_Annotation.data`. Ordered by line.
+
+            Each step of ``module`` is split into ``name``, ``type_name`` and
+            ``instance``, so a consumer can group instances of one module type
+            without parsing ``Linear$3`` itself.
+
+            Identical entries are collapsed. Every member of a fused dispatch
+            attributes separately, and members often share a line, so the same
+            record would otherwise repeat -- once drawn per member, or counted once
+            per member by anything adding the durations up.
+
+        """
+        line_annotations = self._file_line_annotations.get(_normalize_path(filename))
+        if line_annotations is None:
+            return []
+
+        entries: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for line in sorted(line_annotations):
+            for attributed in line_annotations[line]:
+                entry = {
+                    "line": line,
+                    "module": [_module_step(frame) for frame in attributed.module],
+                    **attributed.annotation.data(),
+                }
+                # The whole entry is the identity: for a timing annotation that is
+                # line, module and op ids, and for any other kind whatever it
+                # reports. Serialized because the values include lists.
+                key = json.dumps(entry, sort_keys=True, default=str)
+                if key in seen:
+                    continue
+                seen.add(key)
+                entries.append(entry)
+        return entries
+
     def modules_at(self: Self, filename: str | Path, line: int) -> list[ModulePath]:
         """
         Get the distinct module instance paths attributed to a file and line.
@@ -476,6 +545,9 @@ class _SourceAnnotator:
         listing = _AnnotatedListing(
             lines=[line.rstrip("\n") for line in source_lines],
             header=f"\n# === {file_path} [{module_label}] ===",
+            # Follow the indentation of the annotated line, so a comment sits with
+            # the code it describes instead of breaking out to column zero.
+            align_to_line=True,
         )
 
         line_annotations = self._file_line_annotations.get(

--- a/coreai_torch/debugging/table_writer.py
+++ b/coreai_torch/debugging/table_writer.py
@@ -15,6 +15,8 @@ from typing import Protocol, TextIO, runtime_checkable
 
 from rich.console import Console, RenderableType
 from rich.table import Table
+from rich.text import Text
+from rich.tree import Tree
 from typing_extensions import Self
 
 _DEFAULT_WIDTH = 150
@@ -109,6 +111,35 @@ class _TableSpec:
 
         """
         self.rows.append(row if isinstance(row, _Row) else row.to_row())
+
+
+@dataclass
+class _TreeNode:
+    """A node of a tree to render: its label and the nodes beneath it."""
+
+    label: str
+    """Text for this node. Wraps within the width left by its indentation."""
+
+    children: list[_TreeNode] = field(default_factory=list)
+    """Nodes beneath this one, in display order."""
+
+    style: str = ""
+    """`rich` style applied to this node's label (e.g. ``"dim"``)."""
+
+    def add(self: Self, child: _TreeNode | str) -> _TreeNode:
+        """
+        Append a child node, accepting either a node or a bare label.
+
+        Args:
+            child: The node to append, or a label to wrap in one.
+
+        Returns:
+            The appended node, so a caller can add beneath it.
+
+        """
+        node = _TreeNode(label=child) if isinstance(child, str) else child
+        self.children.append(node)
+        return node
 
 
 def _make_console(
@@ -222,3 +253,44 @@ def _write_table(
 
     """
     _write_renderable(_build_table(spec), output, width=width, color=color)
+
+
+def _build_tree(node: _TreeNode) -> Tree:
+    """
+    Build a `rich` tree from *node*.
+
+    Args:
+        node: The root node.
+
+    Returns:
+        The renderable tree.
+
+    """
+    tree = Tree(Text(node.label, style=node.style) if node.style else node.label)
+    stack = [(node, tree)]
+    while stack:
+        spec_node, rendered = stack.pop()
+        for child in spec_node.children:
+            label = Text(child.label, style=child.style) if child.style else child.label
+            stack.append((child, rendered.add(label)))
+    return tree
+
+
+def _write_tree(
+    node: _TreeNode,
+    output: TextIO | None = None,
+    *,
+    width: int | None = None,
+    color: bool | None = None,
+) -> None:
+    """
+    Render *node* and its descendants to *output*.
+
+    Args:
+        node: The root node.
+        output: Destination stream. Defaults to ``sys.stdout`` when None.
+        width: Console width. Defaults to :data:`_DEFAULT_WIDTH`.
+        color: Force color on or off. When None, `rich` decides from the stream.
+
+    """
+    _write_renderable(_build_tree(node), output, width=width, color=color)

--- a/coreai_torch/debugging/timing_diff.py
+++ b/coreai_torch/debugging/timing_diff.py
@@ -1,0 +1,587 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Comparing the timing of two runs of a model that changed between them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, TextIO
+
+from coreai.authoring import AIProgram
+from coreai.runtime import SpecializationOptions
+from typing_extensions import Self
+
+from .benchmarker import (
+    BenchmarkResult,
+    CoreAIBenchmarker,
+    OperationTiming,
+    _get_default_excluded_operations,
+)
+from .graph_diff import OpIdAlignment, op_id_alignment
+from .graph_match import WeightPolicy
+from .table_writer import _Column, _Row, _TableSpec, _write_table
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MatchedDispatch:
+    """
+    One dispatch covering the same operations either side of an edit.
+
+    "Same" means the same set of Core AI operations, and nothing stronger: the two
+    may be executed by different kernels, at different shapes, or on a different
+    encoder, since kernel selection depends on shapes and on the surrounding graph.
+    So a delta says the cost of these operations moved, not that the same code got
+    faster.
+    """
+
+    before: OperationTiming
+    after: OperationTiming
+
+    modified: bool = False
+    """Whether any of these operations is the same operation wired or configured
+    differently -- ``alignment.modified``. Its delta may be that change rather than a
+    change in cost: doubling a matmul's width shows up here, not as an added
+    operation."""
+
+    @property
+    def median_delta_ms(self) -> float | None:
+        """
+        After minus before.
+
+        Returns:
+            The difference in milliseconds, or None if either side has no
+            statistics.
+
+        """
+        first = self.before.measurement.statistics
+        second = self.after.measurement.statistics
+        if first is None or second is None:
+            return None
+        return second.median - first.median
+
+
+class Resize(Enum):
+    """Whether a dispatch gained or lost operations."""
+
+    GAINED = "gained"
+    """The after dispatch is the before dispatch plus the extra operations."""
+
+    LOST = "lost"
+    """The before dispatch was the after dispatch plus the extra operations."""
+
+
+@dataclass(frozen=True)
+class ResizedDispatch:
+    """
+    The same dispatch either side of an edit, with operations gained or lost.
+
+    Its operations on one side exactly contain the other's, so the two durations are
+    comparable and the difference is attributable to the extra operations -- with the
+    caveat that it also carries any change in what both sides share, and the two
+    cannot be separated.
+
+    Reported apart from :class:`MatchedDispatch` because it is not like for like: the
+    after run did more work, or less.
+    """
+
+    before: OperationTiming
+    after: OperationTiming
+
+    extra_op_ids: frozenset[int]
+    """Operations on the larger side and absent from the smaller. In the after
+    numbering when :attr:`resize` is ``GAINED``; in the before numbering when it is
+    ``LOST``, since an operation that was lost has no after counterpart to name it
+    by."""
+
+    resize: Resize
+    """Which side is larger."""
+
+    modified: bool = False
+    """Whether any shared operation is the same operation wired or configured
+    differently. See :attr:`MatchedDispatch.modified`."""
+
+    @property
+    def median_delta_ms(self) -> float | None:
+        """
+        After minus before.
+
+        Returns:
+            The difference in milliseconds, or None if either side has no statistics.
+            Read as the cost of :attr:`extra_op_ids`, in the direction
+            :attr:`resize` gives.
+
+        """
+        first = self.before.measurement.statistics
+        second = self.after.measurement.statistics
+        if first is None or second is None:
+            return None
+        return second.median - first.median
+
+
+@dataclass(frozen=True)
+class TimingDiff:
+    """
+    What changed between two benchmark runs.
+
+    The lists partition the dispatches: every dispatch of either run appears exactly
+    once -- in :attr:`matched`, in :attr:`resized`, or in the side it is only present
+    on. Nothing is dropped, so a total taken from here accounts for everything
+    measured.
+    """
+
+    matched: list[MatchedDispatch] = field(default_factory=list)
+    """Dispatches covering the same operations either side. Comparable."""
+
+    resized: list[ResizedDispatch] = field(default_factory=list)
+    """Dispatches whose operations one side exactly contains: the same dispatch,
+    having gained or lost some. Comparable, but not like for like."""
+
+    only_before: list[OperationTiming] = field(default_factory=list)
+    """Dispatches present before and not after -- because their operations are gone,
+    or because those operations are now fused differently. Either way this dispatch,
+    the unit the hardware measured, has no counterpart to compare against."""
+
+    only_after: list[OperationTiming] = field(default_factory=list)
+    """Dispatches present after and not before."""
+
+    alignment: OpIdAlignment | None = None
+    """The operation correspondence this comparison was built on."""
+
+    @property
+    def before_dispatches(self: Self) -> list[OperationTiming]:
+        """
+        Every dispatch the before run measured.
+
+        The paired dispatches together with the rest, since a side is split across
+        two of the lists above. Reading :attr:`only_before` alone as "the before
+        dispatches" undercounts by however much did not change, which is usually
+        most of it.
+
+        Returns:
+            The before run's dispatches.
+
+        """
+        return (
+            [pair.before for pair in self.matched]
+            + [resized.before for resized in self.resized]
+            + self.only_before
+        )
+
+    @property
+    def after_dispatches(self: Self) -> list[OperationTiming]:
+        """
+        Every dispatch the after run measured.
+
+        Returns:
+            The after run's dispatches.
+
+        """
+        return (
+            [pair.after for pair in self.matched]
+            + [resized.after for resized in self.resized]
+            + self.only_after
+        )
+
+    def write_to(self: Self, output: TextIO, *, width: int | None = None) -> None:
+        """
+        Write the comparison as a table.
+
+        Args:
+            output: Text stream to write to.
+            width: Console width to render at. Defaults to the table writer's own.
+
+        """
+        spec = _TableSpec(
+            title="Timing comparison",
+            columns=(
+                _Column("Status"),
+                _Column("Operations"),
+                _Column("Before (ms)", justify="right"),
+                _Column("After (ms)", justify="right"),
+                _Column("Delta (ms)", justify="right"),
+            ),
+            caption=(
+                f"{len(self.matched)} comparable "
+                f"({sum(p.modified for p in self.matched)} carrying a modified "
+                f"operation), {len(self.resized)} resized, "
+                f"{len(self.only_before)} only before, "
+                f"{len(self.only_after)} only after. A dispatch present on one side "
+                "only has no counterpart to subtract, and no delta here is calibrated "
+                "against run-to-run variance."
+            ),
+            show_lines=True,
+        )
+
+        for pair in sorted(self.matched, key=lambda p: -abs(p.median_delta_ms or 0.0)):
+            before = pair.before.measurement.statistics
+            after = pair.after.measurement.statistics
+            delta = pair.median_delta_ms
+            spec.add(
+                _Row(
+                    cells=(
+                        "paired (modified)" if pair.modified else "paired",
+                        "\n".join(pair.before.op_names),
+                        f"{before.median:.6f}" if before else "N/A",
+                        f"{after.median:.6f}" if after else "N/A",
+                        f"{delta:+.6f}" if delta is not None else "N/A",
+                    ),
+                ),
+            )
+
+        for resized in sorted(
+            self.resized, key=lambda r: -abs(r.median_delta_ms or 0.0)
+        ):
+            before = resized.before.measurement.statistics
+            after = resized.after.measurement.statistics
+            delta = resized.median_delta_ms
+            ids = ", ".join(str(op_id) for op_id in sorted(resized.extra_op_ids))
+            sign = "+" if resized.resize is Resize.GAINED else "-"
+            spec.add(
+                _Row(
+                    cells=(
+                        f"{resized.resize.value} {len(resized.extra_op_ids)} op(s)"
+                        + (" (modified)" if resized.modified else ""),
+                        "\n".join(resized.before.op_names) + f"\n{sign} ids {ids}",
+                        f"{before.median:.6f}" if before else "N/A",
+                        f"{after.median:.6f}" if after else "N/A",
+                        f"{delta:+.6f}" if delta is not None else "N/A",
+                    ),
+                ),
+            )
+
+        for timing, status in (
+            *((t, "only before") for t in self.only_before),
+            *((t, "only after") for t in self.only_after),
+        ):
+            statistics = timing.measurement.statistics
+            median = f"{statistics.median:.6f}" if statistics else "N/A"
+            spec.add(
+                _Row(
+                    cells=(
+                        status,
+                        "\n".join(timing.op_names),
+                        median if status == "only before" else "--",
+                        median if status == "only after" else "--",
+                        "--",
+                    ),
+                ),
+            )
+
+        _write_table(spec, output, width=width)
+
+
+@dataclass(frozen=True)
+class _Projection:
+    """A dispatch's operations in the after numbering, and what did not survive."""
+
+    mapped: frozenset[int]
+    """Counterparts in the after numbering."""
+
+    unmapped: frozenset[int]
+    """Before ids with no counterpart at all: operations the edit removed."""
+
+
+def _project(timing: OperationTiming, mapping: dict[int, int]) -> _Projection:
+    """
+    Translate a before dispatch's operations into the after run's numbering.
+
+    Core AI op ids are positional, so an edit renumbers them and the two runs have to
+    be compared in one numbering. What failed to translate is kept rather than
+    dropped: a dispatch whose operations all survive can pair exactly, and one that
+    lost some can still be recognised as the same dispatch having lost them.
+
+    Args:
+        timing: A dispatch from the before run.
+        mapping: Before op id -> after op id, from :func:`op_id_alignment`.
+
+    Returns:
+        The translated operations, and those with no counterpart.
+
+    """
+    mapped = {mapping[op_id] for op_id in timing.op_ids if op_id in mapping}
+    unmapped = {op_id for op_id in timing.op_ids if op_id not in mapping}
+    return _Projection(mapped=frozenset(mapped), unmapped=frozenset(unmapped))
+
+
+def _unique_by_set(
+    op_sets: "list[frozenset[int] | None]",
+) -> dict[frozenset[int], int]:
+    """
+    Map each set of operations to the one dispatch covering it.
+
+    Args:
+        op_sets: One entry per dispatch, in dispatch order.
+
+    Returns:
+        Sets covered by exactly one dispatch, mapped to its index. A set covered by
+        more than one is dropped, since two distinct dispatches can cover the same
+        operations and pairing either with a counterpart would be an arbitrary
+        choice. Absent and empty sets are dropped too -- otherwise every dispatch
+        that mapped to nothing would match every other one.
+
+    """
+    by_set: dict[frozenset[int], list[int]] = defaultdict(list)
+    for index, op_set in enumerate(op_sets):
+        if op_set:
+            by_set[op_set].append(index)
+    return {
+        op_set: indices[0] for op_set, indices in by_set.items() if len(indices) == 1
+    }
+
+
+@dataclass(frozen=True)
+class _Correspondence:
+    """Which after dispatch a before dispatch became, and how."""
+
+    after_index: int
+    """Index into the after run's dispatches."""
+
+    resize: Resize | None = None
+    """None when both cover the same operations; otherwise which way it changed."""
+
+    extra_op_ids: frozenset[int] = frozenset()
+    """Operations on the larger side, when :attr:`resize` is set."""
+
+
+@dataclass(frozen=True)
+class _CorrespondenceIndex:
+    """
+    What a before dispatch's counterpart is looked up in.
+
+    Named for the lookup rather than for the after run, since :attr:`added_op_ids`
+    comes from the alignment rather than from that run.
+    """
+
+    sets: list[frozenset[int]]
+    """Each after dispatch's operations, by index."""
+
+    unique: dict[frozenset[int], int]
+    """Operations covered by exactly one after dispatch, to its index."""
+
+    added_op_ids: frozenset[int]
+    """Operations the edit introduced, so a gain can be told from a regrouping."""
+
+
+def _correspond(
+    projection: _Projection,
+    correspondence_index: _CorrespondenceIndex,
+    claimed: set[int],
+) -> _Correspondence | None:
+    """
+    Find the after dispatch a before dispatch became.
+
+    Args:
+        projection: The before dispatch's operations in the after numbering, and those
+            with no counterpart.
+        correspondence_index: What the counterpart is looked up in.
+        claimed: After dispatches already corresponded to something.
+
+    Returns:
+        The correspondence, or None when nothing corresponds -- which is the answer
+        whenever taking one would mean comparing different amounts of work.
+
+    """
+    # The same operations, or the same minus the ones this dispatch lost.
+    after_index = correspondence_index.unique.get(projection.mapped)
+    if after_index is not None:
+        if projection.unmapped:
+            return _Correspondence(after_index, Resize.LOST, projection.unmapped)
+        return _Correspondence(after_index)
+
+    # Operations lost *and* nothing covering what remains: guessing which dispatch
+    # absorbed it would compare different work.
+    if projection.unmapped:
+        return None
+
+    # Exactly one dispatch strictly containing these operations. Two candidates would
+    # make the choice between them arbitrary.
+    containing = [
+        index
+        for index, op_set in enumerate(correspondence_index.sets)
+        if index not in claimed and op_set > projection.mapped
+    ]
+    if len(containing) != 1:
+        return None
+
+    # And the extra operations have to be new. Ones that existed before and merely
+    # moved into this dispatch are a regrouping, not a gain: calling them gained
+    # blames the edit for work it did not add, and counts them twice when the dispatch
+    # they came from corresponded elsewhere.
+    extra_op_ids = correspondence_index.sets[containing[0]] - projection.mapped
+    if not extra_op_ids <= correspondence_index.added_op_ids:
+        return None
+    return _Correspondence(containing[0], Resize.GAINED, extra_op_ids)
+
+
+def compare_results(
+    alignment: OpIdAlignment,
+    before: BenchmarkResult,
+    after: BenchmarkResult,
+) -> TimingDiff:
+    """
+    Compare two runs, given the operation correspondence between them.
+
+    Pure, and deliberately so: pairing is where this can be subtly wrong, and keeping
+    it free of programs and devices is what makes it testable.
+
+    A dispatch pairs only with one covering the same operations. Anything else is
+    reported as present on one side only rather than compared, because a dispatch
+    whose composition changed measures a different amount of work -- comparing a
+    six-operation kernel against the two three-operation kernels it became would
+    report a change of denominator as a change in cost.
+
+    Args:
+        alignment: Which before operation became which after operation, from
+            :func:`op_id_alignment`.
+        before: The "before" run.
+        after: The "after" run.
+
+    Returns:
+        What changed, as a partition of both runs' dispatches.
+
+    """
+    projections = [
+        _project(timing, alignment.mapping) for timing in before.operation_timings
+    ]
+    after_sets = [frozenset(timing.op_ids) for timing in after.operation_timings]
+
+    # Indexed by operations covered, since a dispatch has no other stable identity: a
+    # compile identifier is a per-dispatch counter, and op ids renumber across an edit.
+    before_unique = _unique_by_set([projection.mapped for projection in projections])
+    correspondence_index = _CorrespondenceIndex(
+        sets=after_sets,
+        unique=_unique_by_set(after_sets),
+        added_op_ids=frozenset(alignment.added),
+    )
+
+    matched: list[MatchedDispatch] = []
+    resized: list[ResizedDispatch] = []
+    paired_before: set[int] = set()
+    paired_after: set[int] = set()
+
+    # Iterated in before-dispatch order, so the outcome does not depend on how a
+    # frozenset happens to hash.
+    for index in before_unique.values():
+        found = _correspond(projections[index], correspondence_index, paired_after)
+        if found is None:
+            continue
+
+        first = before.operation_timings[index]
+        second = after.operation_timings[found.after_index]
+        modified = bool(set(first.op_ids) & alignment.modified)
+
+        if found.resize is None:
+            matched.append(MatchedDispatch(first, second, modified))
+        else:
+            resized.append(
+                ResizedDispatch(
+                    first, second, found.extra_op_ids, found.resize, modified
+                ),
+            )
+        paired_before.add(index)
+        paired_after.add(found.after_index)
+
+    return TimingDiff(
+        matched=matched,
+        resized=resized,
+        only_before=[
+            timing
+            for index, timing in enumerate(before.operation_timings)
+            if index not in paired_before
+        ],
+        only_after=[
+            timing
+            for index, timing in enumerate(after.operation_timings)
+            if index not in paired_after
+        ],
+        alignment=alignment,
+    )
+
+
+async def compare_runs(
+    before_program: AIProgram,
+    after_program: AIProgram,
+    inputs: dict[str, Any],
+    num_runs: int = 1,
+    entry_point: str = "main",
+    *,
+    excluded_operations: tuple[str, ...] | None = None,
+    specialization_options: SpecializationOptions | None = None,
+    weights: WeightPolicy = WeightPolicy.IGNORE,
+) -> TimingDiff:
+    """
+    Benchmark both programs under identical settings and compare them.
+
+    One call rather than two benchmarks a caller pairs up, because a difference in
+    iteration count, excluded operations or specialization options can dwarf the edit
+    being measured. The runs are still sequential, so whatever drifts over the call --
+    clocks, thermals, other load -- lands on the second one.
+
+    Args:
+        before_program: The "before" program.
+        after_program: The "after" program.
+        inputs: Inputs for both, so the edit is assumed not to have changed them.
+        num_runs: Timed iterations per program, each preceded by an untimed warmup so
+            the samples describe the steady state either side. Worth raising: every
+            number reported here is a difference of two measurements, so it carries
+            both their noise, and a single sample apiece leaves no spread to judge
+            whether a delta means anything.
+        entry_point: Function to benchmark and compare.
+        excluded_operations: Operations not to time, defaulting as
+            :func:`~coreai_torch.debugging.benchmarker.benchmark_coreai_program` does.
+            Applied to both runs. Not merely cosmetic here: a dispatch is identified by
+            the operations it covers, so an untimed operation left in that set makes
+            pairing turn on it, and a constant the edit happened to add would strand an
+            otherwise unchanged dispatch on one side.
+        specialization_options: Specialization options. Applied to both runs.
+        weights: Whether parameter values count towards an operation's identity.
+
+    Returns:
+        What changed between the two runs.
+
+    Raises:
+        ValueError: If either run attributed no dispatches. Comparing two empty runs
+            reports that nothing changed, which reads exactly like a working
+            comparison.
+
+    """
+    alignment = op_id_alignment(
+        before_program, after_program, entry_point, weights=weights
+    )
+
+    if excluded_operations is None:
+        excluded_operations = _get_default_excluded_operations()
+
+    results: list[BenchmarkResult] = []
+    for program in (before_program, after_program):
+        benchmarker = CoreAIBenchmarker(
+            program, entry_point, excluded_operations, specialization_options
+        )
+        results.append(await benchmarker.benchmark(inputs, num_runs))
+
+    for label, result in zip(("before", "after"), results, strict=True):
+        if not result.operation_timings:
+            msg = (
+                f"The {label} run attributed no dispatches, so there is nothing to "
+                "compare. Per-operation timing needs the GPU delegate: check that the "
+                "specialization options select it."
+            )
+            raise ValueError(msg)
+
+    if alignment.identical:
+        logger.info(
+            "The two programs are the same graph, so any difference measured here is "
+            "run-to-run variance rather than the effect of an edit.",
+        )
+
+    return compare_results(alignment, *results)

--- a/coreai_torch/debugging/utils.py
+++ b/coreai_torch/debugging/utils.py
@@ -60,6 +60,26 @@ def _walk_operations(coreai_program: AIProgram) -> list[Operation]:
     return [operation for operation, _ in _walk_operation(module)]
 
 
+def split_module_frame(frame: str) -> tuple[str, int | None]:
+    """
+    Split a stack-trace module frame into its type and instance number.
+
+    A frame names an instance, not a type -- ``Linear$3`` is the third ``Linear``.
+    Splitting is what lets a caller group instances of one type together without
+    re-parsing the name itself.
+
+    Args:
+        frame: Module frame as the stack trace gives it, e.g. ``"Linear$3"``.
+
+    Returns:
+        The type name and the instance number, the latter None when the frame
+        carries no number (``<unknown>``, or a name with no ``$``).
+
+    """
+    type_name, _, suffix = frame.partition("$")
+    return type_name, int(suffix) if suffix.isdigit() else None
+
+
 @dataclass(frozen=True)
 class LocationInfo:
     """

--- a/tests/debugging/test_benchmarker.py
+++ b/tests/debugging/test_benchmarker.py
@@ -115,15 +115,20 @@ async def test_module_timings(
         has_content = len(module.operation_timings) > 0 or len(module.children) > 0
         assert has_content, f"Module {module_name} should have operations or children"
 
-        # If module has operations, check total_time
+        # A module reports no total -- fusion crosses module boundaries, so one
+        # would charge a module for a sibling's work. Its dispatches carry the
+        # timing instead.
         if module.operation_timings:
-            total_time_stats = module.total_time
-            assert total_time_stats is not None, (
-                f"Module {module_name} should have timing statistics"
-            )
-            assert total_time_stats.average > 0, (
-                f"Module {module_name} should have positive average time"
-            )
+            for timing in module.get_all_operations():
+                assert timing.measurement.statistics is not None, (
+                    f"Dispatch {timing.op_ids} in {module_name} should have statistics"
+                )
+
+        # type_name and instance split the frame the stack trace gave
+        assert module.type_name, "Module should have a type name"
+        assert module.instance is None or module.instance > 0, (
+            f"Module {module_name} instance should be positive when known"
+        )
 
         # Test write_to method - we can't easily test TextIO output directly,
         # but we can verify it doesn't throw an error

--- a/tests/debugging/test_graph_diff.py
+++ b/tests/debugging/test_graph_diff.py
@@ -18,6 +18,7 @@ from coreai_torch.debugging.graph_diff import (
     compute_exported_program_diff,
     compute_per_graph_diff,
     format_multi_graph_diff,
+    op_id_alignment,
     write_diff,
 )
 
@@ -442,3 +443,49 @@ async def test_compute_coreai_program_diff_all_graphs() -> None:
     # Should have computed a diff
     assert diff.summary.source_node_count > 0
     assert diff.summary.target_node_count > 0
+
+
+@pytest.mark.asyncio
+async def test_op_id_alignment_identical_programs() -> None:
+    """An unchanged model maps every operation to itself, and says so."""
+    model = ThreeLinearModel().eval()
+    args = tuple(get_example_inputs(ThreeLinearModel).values())
+
+    exported = torch.export.export(model, args).run_decompositions()
+    before = await _create_coreai_program_from_model(exported)
+    after = await _create_coreai_program_from_model(
+        torch.export.export(model, args).run_decompositions()
+    )
+
+    alignment = op_id_alignment(before, after)
+
+    assert alignment.identical, "Rebuilding the same model should be the same graph"
+    assert alignment.mapping, "Should map operations"
+    assert not alignment.removed
+    assert not alignment.added
+    assert not alignment.modified
+    # Nothing moved, so every operation keeps its id -- which is exactly why raw ids
+    # look safe to compare until an edit renumbers them.
+    assert all(source == target for source, target in alignment.mapping.items())
+
+
+@pytest.mark.asyncio
+async def test_op_id_alignment_survives_an_added_layer() -> None:
+    """An added layer renumbers ids; the mapping still pairs what survived."""
+    args = tuple(get_example_inputs(ThreeLinearModel).values())
+    before = await _create_coreai_program_from_model(
+        torch.export.export(ThreeLinearModel().eval(), args).run_decompositions()
+    )
+    after = await _create_coreai_program_from_model(
+        torch.export.export(ExtraLayerModel().eval(), args).run_decompositions()
+    )
+
+    alignment = op_id_alignment(before, after)
+
+    assert not alignment.identical, "An added layer is a different graph"
+    assert alignment.mapping, "Operations either side of the addition should pair"
+    assert alignment.added, "The added layer's operations have no counterpart"
+    # A mapped pair is one operation, so no id may be claimed twice on either side.
+    assert len(set(alignment.mapping.values())) == len(alignment.mapping)
+    assert not set(alignment.mapping) & set(alignment.removed)
+    assert not set(alignment.mapping.values()) & set(alignment.added)

--- a/tests/debugging/test_timing_diff.py
+++ b/tests/debugging/test_timing_diff.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Tests for comparing two benchmark runs.
+
+Pairing is exercised without a device: it reads only ``op_ids`` and the alignment, so
+a dispatch can be built with no operations behind it. That keeps the classification
+-- the part that can be subtly wrong -- testable.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from coreai_torch.debugging.benchmarker import (
+    BenchmarkResult,
+    Measurement,
+    OperationTiming,
+)
+from coreai_torch.debugging.graph_diff import OpIdAlignment
+from coreai_torch.debugging.timing_diff import Resize, compare_results
+
+
+def _dispatch(op_ids: list[int], median_ms: float) -> OperationTiming:
+    """A dispatch covering *op_ids*, measured at *median_ms* every sample."""
+    return OperationTiming(
+        op_ids=op_ids,
+        operations=[],
+        measurement=Measurement.from_samples([median_ms] * 3),
+    )
+
+
+def _result(*timings: OperationTiming) -> BenchmarkResult:
+    """A benchmark result holding *timings*."""
+    return BenchmarkResult(operation_timings=list(timings))
+
+
+def _identity(op_ids: range | list[int]) -> OpIdAlignment:
+    """An alignment where every operation kept its id."""
+    return OpIdAlignment(mapping={op_id: op_id for op_id in op_ids}, identical=True)
+
+
+def test_unchanged_dispatches_pair() -> None:
+    """Identical dispatches pair, and the delta is zero."""
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([3], 0.25))
+    after = _result(_dispatch([1, 2], 0.5), _dispatch([3], 0.25))
+
+    diff = compare_results(_identity(range(1, 4)), before, after)
+
+    assert len(diff.matched) == 2
+    assert not diff.only_before
+    assert not diff.only_after
+    assert all(pair.median_delta_ms == 0.0 for pair in diff.matched)
+
+
+def test_delta_is_after_minus_before() -> None:
+    """A dispatch that got slower reports a positive delta."""
+    before = _result(_dispatch([1, 2], 0.5))
+    after = _result(_dispatch([1, 2], 0.75))
+
+    diff = compare_results(_identity(range(1, 3)), before, after)
+
+    assert len(diff.matched) == 1
+    assert diff.matched[0].median_delta_ms == 0.25
+
+
+def test_split_fusion_does_not_pair() -> None:
+    """A kernel that split covers different operations, so nothing is compared.
+
+    Pairing (1,2,3) with either half would compare a three-operation dispatch
+    against a two-operation one and report the change of denominator as a cost.
+    """
+    before = _result(_dispatch([1, 2, 3], 0.9))
+    after = _result(_dispatch([1, 2], 0.5), _dispatch([3, 4], 0.5))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2, 3: 3}, added=[4]), before, after
+    )
+
+    assert not diff.matched
+    assert [t.op_ids for t in diff.only_before] == [[1, 2, 3]]
+    assert [t.op_ids for t in diff.only_after] == [[1, 2], [3, 4]]
+
+
+def test_removed_operations_leave_a_dispatch_on_one_side() -> None:
+    """A dispatch whose operations are gone has no counterpart."""
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([9], 0.1))
+    after = _result(_dispatch([1, 2], 0.5))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2}, removed=[9]), before, after
+    )
+
+    assert len(diff.matched) == 1
+    assert [t.op_ids for t in diff.only_before] == [[9]]
+    assert not diff.only_after
+
+
+def test_renumbered_operations_still_pair() -> None:
+    """An edit that renumbers ids pairs on the correspondence, not on the ids.
+
+    This is the case raw ids get wrong: comparing by id would find no dispatch at
+    (11, 12) before and report the whole model as replaced.
+    """
+    before = _result(_dispatch([1, 2], 0.5))
+    after = _result(_dispatch([11, 12], 0.5))
+
+    diff = compare_results(OpIdAlignment(mapping={1: 11, 2: 12}), before, after)
+
+    assert len(diff.matched) == 1
+    assert diff.matched[0].before.op_ids == [1, 2]
+    assert diff.matched[0].after.op_ids == [11, 12]
+
+
+def test_a_dispatch_that_lost_an_operation_is_resized_not_matched() -> None:
+    """A dispatch missing an operation is the same dispatch, resized.
+
+    (1,2,9) with 9 removed leaves (1,2), which the after dispatch covers exactly. It
+    is not a like-for-like pair -- the before run did more work -- so it is reported
+    as a loss of operation 9 rather than as matched, and the delta reads as the cost
+    of that operation.
+    """
+    before = _result(_dispatch([1, 2, 9], 0.9))
+    after = _result(_dispatch([1, 2], 0.5))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2}, removed=[9]), before, after
+    )
+
+    assert not diff.matched, "Not the same operations"
+    assert len(diff.resized) == 1
+    resized = diff.resized[0]
+    assert resized.resize is Resize.LOST
+    assert resized.extra_op_ids == frozenset({9})
+    assert resized.median_delta_ms == -0.4
+    assert not diff.only_before
+    assert not diff.only_after
+
+
+def test_a_dispatch_that_gained_an_operation_is_resized() -> None:
+    """A dispatch with one more operation is the same dispatch, resized.
+
+    The delta is the cost of the operation it gained -- which is the reading an
+    author wants after adding one, and which reporting both sides as unpaired denies
+    them.
+    """
+    before = _result(_dispatch([1, 2], 0.5))
+    after = _result(_dispatch([1, 2, 3], 0.7))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2}, added=[3]), before, after
+    )
+
+    assert not diff.matched
+    assert len(diff.resized) == 1
+    resized = diff.resized[0]
+    assert resized.resize is Resize.GAINED
+    assert resized.extra_op_ids == frozenset({3})
+    assert resized.median_delta_ms == pytest.approx(0.2)
+
+
+def test_operations_that_merely_moved_are_not_a_gain() -> None:
+    """A dispatch absorbing an operation that already existed is not a gain.
+
+    Operation 1 exists before, in its own dispatch. After the edit it sits alongside 2
+    in one dispatch. Calling that "gained 1" blames the edit for work it did not add,
+    and counts operation 1 twice -- once in its own pair, once as the gain.
+    """
+    before = _result(_dispatch([1], 0.2), _dispatch([2], 0.5))
+    after = _result(_dispatch([1], 0.2), _dispatch([1, 2], 0.7))
+
+    diff = compare_results(_identity([1, 2]), before, after)
+
+    assert not diff.resized, "Operation 1 was not added by the edit"
+    assert [t.op_ids for t in diff.only_before] == [[2]]
+    assert [t.op_ids for t in diff.only_after] == [[1, 2]]
+    # The dispatch that did not change still pairs.
+    assert [p.before.op_ids for p in diff.matched] == [[1]]
+
+
+def test_two_candidate_supersets_are_not_resized_arbitrarily() -> None:
+    """Two dispatches could contain these operations, so neither is chosen."""
+    before = _result(_dispatch([1, 2], 0.5))
+    after = _result(_dispatch([1, 2, 3], 0.7), _dispatch([1, 2, 4], 0.7))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2}, added=[3, 4]), before, after
+    )
+
+    assert not diff.matched
+    assert not diff.resized, "Neither superset is more correct than the other"
+    assert len(diff.only_before) == 1
+    assert len(diff.only_after) == 2
+
+
+def test_ambiguous_sets_are_not_paired_arbitrarily() -> None:
+    """Two dispatches covering the same operations cannot be paired one to one."""
+    before = _result(_dispatch([1], 0.5), _dispatch([1], 0.6))
+    after = _result(_dispatch([1], 0.5), _dispatch([1], 0.6))
+
+    diff = compare_results(_identity([1]), before, after)
+
+    assert not diff.matched, "Neither pairing is more correct than the other"
+    assert len(diff.only_before) == 2
+    assert len(diff.only_after) == 2
+
+
+def test_a_modified_operation_marks_the_pair() -> None:
+    """A pair holding a rewired operation is flagged, not silently compared.
+
+    `align` folds a modified operation into `mapping` so its dispatch still pairs --
+    dropping it would discard most of the comparison, since any reshape produces one.
+    But its delta may be the reconfiguration rather than a change in cost.
+    """
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([3], 0.2))
+    after = _result(_dispatch([1, 2], 0.6), _dispatch([3], 0.2))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2, 3: 3}, modified={2}), before, after
+    )
+
+    by_ids = {tuple(pair.before.op_ids): pair for pair in diff.matched}
+    assert by_ids[(1, 2)].modified, "Operation 2 was modified"
+    assert not by_ids[(3,)].modified, "Operation 3 was not"
+
+
+def test_dispatches_are_partitioned() -> None:
+    """Every dispatch appears exactly once, so nothing is silently dropped."""
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([3], 0.2), _dispatch([9], 0.1))
+    after = _result(_dispatch([1, 2], 0.4), _dispatch([3, 4], 0.3))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2, 3: 3}, removed=[9], added=[4]),
+        before,
+        after,
+    )
+
+    assert len(diff.matched) + len(diff.resized) + len(diff.only_before) == len(
+        before.operation_timings
+    )
+    assert len(diff.matched) + len(diff.resized) + len(diff.only_after) == len(
+        after.operation_timings
+    )
+
+
+def test_side_accessors_return_the_whole_side() -> None:
+    """Each side lists every dispatch that run measured, paired ones included.
+
+    Reading ``only_before`` alone would undercount by whatever did not change, which
+    is the flattering direction: an edit would look like it removed dispatches it
+    left alone.
+    """
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([3], 0.2), _dispatch([9], 0.1))
+    after = _result(_dispatch([1, 2], 0.4), _dispatch([3], 0.2), _dispatch([4], 0.3))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2, 3: 3}, removed=[9], added=[4]),
+        before,
+        after,
+    )
+
+    assert len(diff.matched) == 2, "The unchanged dispatches should pair"
+    assert diff.before_dispatches == before.operation_timings
+    assert diff.after_dispatches == after.operation_timings
+    # And the accessors are the partition, reassembled.
+    assert len(diff.before_dispatches) == len(diff.matched) + len(diff.resized) + len(
+        diff.only_before
+    )
+    assert len(diff.after_dispatches) == len(diff.matched) + len(diff.resized) + len(
+        diff.only_after
+    )
+
+
+def test_write_to_reports_every_dispatch() -> None:
+    """The table names each dispatch, whichever side it is on."""
+    before = _result(_dispatch([1, 2], 0.5), _dispatch([9], 0.1))
+    after = _result(_dispatch([1, 2], 0.4), _dispatch([3], 0.2))
+
+    diff = compare_results(
+        OpIdAlignment(mapping={1: 1, 2: 2}, removed=[9], added=[3]), before, after
+    )
+    buffer = StringIO()
+    diff.write_to(buffer, width=120)
+    written = buffer.getvalue()
+
+    assert "paired" in written
+    assert "only before" in written
+    assert "only after" in written
+    assert "1 comparable" in written


### PR DESCRIPTION
The runtime measures a compile identifier -- a possibly-fused group of Core AI operations -- as a whole, so a duration belongs to the group rather than to any one member. It also reports each encoder twice; only one of the two measurements is kept now, since pooling them put two different quantities in one sample list.

- `OperationTiming` carries `op_ids` and one undivided `measurement`, and the summary lists every member rather than a representative, which collided.
- `_timings` is keyed on `(odix_id, sorted op ids)`: `delegate_id` is a per-dispatch counter, and an unsorted key split one dispatch across rows.
- An untimed warmup iteration, since a first inference is not the steady state.
- `operations_by_id` exposes every operation in the function, so a caller can compute coverage on its own terms.
- Module timings are filed against the deepest module containing all of a dispatch's operations, and no module reports a total: fusion crosses module boundaries, so a total charges one module for a sibling's work.
- Removed `total_duration_ns` and the per-operation lookups, which presented a profiling span and a shared duration as latency and per-operation cost.

Adds `timing_diff` for comparing two runs. Op ids are positional, so an edit renumbers them and comparing by id compares unrelated work. `op_id_alignment` supplies the correspondence, and dispatches pair only when they cover the same operations; one that gained or lost operations is reported as resized, with the delta attributable to them, and anything else as present on one side only.
