### PR TITLE
Resolve externalized call sites by op target, not by recorded node name

### DIFF
--- a/coreai_torch/_utils.py
+++ b/coreai_torch/_utils.py
@@ -1571,6 +1571,19 @@ def _find_all_custom_op_nodes(
     ]
 
 
+def _externalized_op_name(target: object) -> str | None:
+    """The externalized op's name for a call target, or ``None`` if it is not one.
+
+    The inverse of the lookups above: use it to bucket a graph's nodes by op in
+    one pass, rather than re-walking the graph once per op name.
+    """
+    text = str(target)
+    prefix = f"{_EXTERNALIZE_NAMESPACE}."
+    if not text.startswith(prefix):
+        return None
+    return text[len(prefix) :].rsplit(".", 1)[0]
+
+
 def _fake_inputs_from_node(node: fx.Node) -> tuple[torch.Tensor, ...]:
     """Extract concrete example tensors from a node's FakeTensor args.
 

--- a/coreai_torch/converter.py
+++ b/coreai_torch/converter.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -44,7 +45,7 @@ from ._debug_locations import _DebugInfoRecorder
 from ._torch_metal_kernel import TorchMetalKernel
 from ._utils import (
     _NARROW_TORCH_DTYPE,
-    _find_all_custom_op_nodes,
+    _externalized_op_name,
     _get_mutation_output_name,
     _get_verify_debuginfo_locations_enabled,
     _ProgressBar,
@@ -357,31 +358,51 @@ class TorchConverter:
         :meth:`add_exported_program`, and a transform that renames nodes leaves
         those names matching nothing, so the per-node lowerings below are never
         found. The custom op target survives such transforms, so call sites are
-        located by target and paired with their
-        :class:`_ExternalizedExportedProgram` in graph order, which is the
-        order they were prepared in.
+        located by target instead.
 
-        An op whose call-site count no longer matches is left to its recorded
-        names: a differing count means the graph changed shape rather than just
-        its names, and pairing by position would attach a lowering to the wrong
-        call site.
+        Several call sites of one op are paired with their
+        :class:`_ExternalizedExportedProgram` in graph order, which is the
+        order they were prepared in. This assumes a transform preserves the
+        relative order of an op's call sites, as renaming and the usual
+        lowering passes do; one that reorders them would pair the wrong way
+        round.
+
+        An op whose call-site count no longer matches keeps its recorded names,
+        since a differing count means the graph changed shape rather than just
+        its names, and pairing by position would then be meaningless.
         """
         by_op: dict[str, list[_ExternalizedExportedProgram]] = defaultdict(list)
         for ext in exts:
             by_op[ext.op_name].append(ext)
 
         # A nested submodule's call site lives in its parent's program, not the
-        # whole-model one, so both are searched.
+        # whole-model one, so every program is searched. One pass over each,
+        # bucketing by op, keeps this linear in total graph size.
         programs = [self.exported_program] + [e.exported_program for e in exts]
+        nodes_by_op: dict[str, list[str]] = defaultdict(list)
+        for program in programs:
+            for node in program.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                op_name = _externalized_op_name(node.target)
+                if op_name in by_op:
+                    nodes_by_op[op_name].append(node.name)
 
         resolved: dict[int, list[str]] = {}
         for op_name, group in by_op.items():
-            found: list[str] = []
-            for program in programs:
-                found.extend(
-                    node.name for node in _find_all_custom_op_nodes(program, op_name)
-                )
+            found = nodes_by_op[op_name]
             if len(found) != len(group):
+                warnings.warn(
+                    f"coreai_torch.externalize: op '{op_name}' has "
+                    f"{len(found)} call site(s) in the programs being "
+                    f"converted but {len(group)} prepared submodule(s). "
+                    f"Falling back to the node names recorded at preparation "
+                    f"time, which a graph transform may have invalidated. "
+                    f"Action: convert the program the submodules were prepared "
+                    f"from, or one derived from it without adding or removing "
+                    f"call sites.",
+                    stacklevel=3,
+                )
                 continue
             for ext, node_name in zip(group, found):
                 resolved[id(ext)] = [node_name]

--- a/coreai_torch/converter.py
+++ b/coreai_torch/converter.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -44,6 +44,7 @@ from ._debug_locations import _DebugInfoRecorder
 from ._torch_metal_kernel import TorchMetalKernel
 from ._utils import (
     _NARROW_TORCH_DTYPE,
+    _find_all_custom_op_nodes,
     _get_mutation_output_name,
     _get_verify_debuginfo_locations_enabled,
     _ProgressBar,
@@ -345,6 +346,47 @@ class TorchConverter:
         )
         self.exported_program = whole_ep
 
+    def _resolve_source_nodes(
+        self, exts: list[_ExternalizedExportedProgram]
+    ) -> dict[int, list[str]]:
+        """Locate each externalized call site in the programs being converted.
+
+        ``source_nodes`` holds FX node names as they were when the submodules
+        were prepared. The two-step API lets a caller transform the graph
+        between :func:`_subexport_and_restore` and
+        :meth:`add_exported_program`, and a transform that renames nodes leaves
+        those names matching nothing, so the per-node lowerings below are never
+        found. The custom op target survives such transforms, so call sites are
+        located by target and paired with their
+        :class:`_ExternalizedExportedProgram` in graph order, which is the
+        order they were prepared in.
+
+        An op whose call-site count no longer matches is left to its recorded
+        names: a differing count means the graph changed shape rather than just
+        its names, and pairing by position would attach a lowering to the wrong
+        call site.
+        """
+        by_op: dict[str, list[_ExternalizedExportedProgram]] = defaultdict(list)
+        for ext in exts:
+            by_op[ext.op_name].append(ext)
+
+        # A nested submodule's call site lives in its parent's program, not the
+        # whole-model one, so both are searched.
+        programs = [self.exported_program] + [e.exported_program for e in exts]
+
+        resolved: dict[int, list[str]] = {}
+        for op_name, group in by_op.items():
+            found: list[str] = []
+            for program in programs:
+                found.extend(
+                    node.name for node in _find_all_custom_op_nodes(program, op_name)
+                )
+            if len(found) != len(group):
+                continue
+            for ext, node_name in zip(group, found):
+                resolved[id(ext)] = [node_name]
+        return resolved
+
     def _perform_externalization(self, context) -> None:
         """Emit externalized submodule graphs and register their lowerings.
 
@@ -363,6 +405,9 @@ class TorchConverter:
             return
 
         whole_program: ExportedProgram = self.exported_program
+        resolved_nodes = self._resolve_source_nodes(
+            self._externalized_exported_programs
+        )
 
         # Process deepest modules first so their lowerings exist
         # when parent modules are built.
@@ -400,7 +445,7 @@ class TorchConverter:
             )
 
             # Register per-node lowering: node.name → coreai.invoke @graph
-            for node_name in ext.source_nodes:
+            for node_name in resolved_nodes.get(id(ext), ext.source_nodes):
                 self._externalized_lowerings[node_name] = (
                     lambda values_map, node, loc, _gop=graph_op: get_invoke_from_graph(
                         values_map, node, loc, _gop

--- a/tests/test_externalize.py
+++ b/tests/test_externalize.py
@@ -4162,10 +4162,26 @@ def test_call_sites_resolved_after_a_renaming_transform() -> None:
         .to_coreai()
     )
 
-    pattern = """
-    // CHECK-COUNT-2: coreai.invoke
+    # Capturing the graph names ties each invoke to a distinct submodule, so a
+    # resolution that collapsed both call sites onto one lowering would fail.
+    check_file = """
+        // CHECK-LABEL: module {
+        // CHECK:   coreai.graph private noinline @[[NORM0:norm\\.rmsnorm_impl_[0-9a-f]+]](
+        // CHECK-SAME: composite_decl = #coreai.composite_declaration<"rms_norm"
+        // CHECK:     coreai.output
+        // CHECK:   }
+        // CHECK:   coreai.graph private noinline @[[NORM1:norm\\.rmsnorm_impl_[0-9a-f]+]](
+        // CHECK-SAME: composite_decl = #coreai.composite_declaration<"rms_norm"
+        // CHECK:     coreai.output
+        // CHECK:   }
+        // CHECK:   coreai.graph @main(
+        // CHECK:     coreai.invoke @[[NORM0]](
+        // CHECK:     coreai.invoke @[[NORM1]](
+        // CHECK:     coreai.output
+        // CHECK:   }
+        // CHECK: }
     """
-    filecheck_pattern(str(coreai_program.get_graph("main")), pattern)
+    filecheck_pattern(str(coreai_program), check_file=check_file)
 
 
 def test_mismatched_call_site_count_warns_and_falls_back() -> None:

--- a/tests/test_externalize.py
+++ b/tests/test_externalize.py
@@ -4103,3 +4103,101 @@ async def test_externalize_multiple_staged_entries_numerics() -> None:
     await _validate_numerics(
         coreai_program, plain_model, plain_sample, function_name="plain"
     )
+
+
+def test_call_sites_resolved_after_a_renaming_transform() -> None:
+    """A transform between sub-export and conversion may rename every node.
+
+    ``_ExternalizedExportedProgram.source_nodes`` records the names as they
+    were at preparation time, so a lowering keyed on them would find nothing.
+    The two call sites also check that they are matched up in graph order
+    rather than collapsed onto one.
+    """
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = RMSNorm(dim=DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.norm(x) + self.norm(x * 2.0)
+
+    torch.manual_seed(42)
+    model = Model().eval()
+    sample = (torch.randn(2, DIM),)
+
+    _patch_model_for_externalization(
+        model,
+        [
+            ExternalizeSpec(
+                target_class=RMSNormImpl,
+                composite_op_name="rms_norm",
+                composite_attrs=["axes", "eps", "version"],
+            )
+        ],
+    )
+    ep = torch.export.export(model, args=sample).run_decompositions(get_decomp_table())
+    externalized_exported_programs = _subexport_and_restore(model, ep)
+    assert len(externalized_exported_programs) == 2, (
+        f"expected one entry per call site, got {len(externalized_exported_programs)}"
+    )
+
+    recorded = [
+        name for ext in externalized_exported_programs for name in ext.source_nodes
+    ]
+    # Only the call sites need renaming to invalidate source_nodes; the graph
+    # signature keys placeholders and outputs by name, so leave those alone.
+    for index, node in enumerate(ep.graph.nodes):
+        if node.op == "call_function":
+            node.name = f"renamed_{index}"
+    assert not (set(recorded) & {node.name for node in ep.graph.nodes}), (
+        "the rename should have invalidated every recorded name"
+    )
+
+    coreai_program = (
+        TorchConverter()
+        .add_exported_program(
+            ep, _externalized_exported_programs=externalized_exported_programs
+        )
+        .to_coreai()
+    )
+
+    pattern = """
+    // CHECK-COUNT-2: coreai.invoke
+    """
+    filecheck_pattern(str(coreai_program.get_graph("main")), pattern)
+
+
+def test_mismatched_call_site_count_warns_and_falls_back() -> None:
+    """A graph that gained or lost call sites cannot be paired by position.
+
+    Resolution is skipped for that op and the recorded names are used, which
+    is unlikely to work, so the fallback says so rather than failing later
+    with an unhandled custom op.
+    """
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = RMSNorm(dim=DIM)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.norm(x)
+
+    torch.manual_seed(42)
+    model = Model().eval()
+    sample = (torch.randn(2, DIM),)
+
+    _patch_model_for_externalization(model, [ExternalizeSpec(target_class=RMSNormImpl)])
+    ep = torch.export.export(model, args=sample).run_decompositions(get_decomp_table())
+    externalized_exported_programs = _subexport_and_restore(model, ep)
+
+    # Stand in for a transform that dropped a call site: one prepared
+    # submodule too many for the graph being converted.
+    duplicated = externalized_exported_programs * 2
+
+    converter = TorchConverter().add_exported_program(
+        ep, _externalized_exported_programs=duplicated
+    )
+    with pytest.warns(UserWarning, match="prepared submodule"):
+        converter.to_coreai()


### PR DESCRIPTION
### Problem

`add_exported_program(_externalized_exported_programs=...)` is documented to emit
composite graphs "for the patched call sites in `exported_program`", but it
registers each lowering under `_ExternalizedExportedProgram.source_nodes` — FX
node *names* captured back when `_subexport_and_restore` ran.

The two-step API introduced in #53 exists precisely so a caller can do work
between the phases; `_patch_model_for_externalization`'s own docstring shows
`ep = my_export_or_quantize_pipeline(model)`. Any pass in that window that
rebuilds or renames nodes leaves the recorded names matching nothing. The
lowerings are then registered under dead keys, and conversion fails later with
an opaque error that names neither the submodule nor the cause:

    ValueError: unable to handle call function op:
      target: norm_rmsnorm_impl_7b5f5a2a.default, namespace: coreai_torch_ext

The call sites are still there — only their names changed. The custom op target
survives any such transform.

### Fix

`TorchConverter._resolve_source_nodes` locates each call site by op target and
pairs it with its `_ExternalizedExportedProgram`, falling back to the recorded
names when it cannot. `_perform_externalization` uses the resolved names.

- One pass per program, bucketing nodes by op, so cost stays linear in total
  graph size rather than one graph walk per op name.
- Every program is searched, not just the whole-model one: a nested submodule's
  call site lives in its parent's program.
- Multiple call sites of one op are paired in graph order, which is preparation
  order. This assumes a transform preserves the relative order of an op's call
  sites, as renaming and the usual lowering passes do.
- If an op's call-site count no longer matches its prepared submodules, the
  graph changed shape rather than just its names, so pairing by position would
  be meaningless. That op keeps its recorded names and a `UserWarning` explains
  why, instead of silently degrading to the error above.

`_utils._externalized_op_name` is the inverse of the existing
`_find_custom_op_node` / `_find_all_custom_op_nodes` lookups and shares
`_EXTERNALIZE_NAMESPACE` with them.

### Tests

- `test_call_sites_resolved_after_a_renaming_transform` — renames every
  `call_function` node between `_subexport_and_restore` and
  `add_exported_program`, then asserts both call sites still lower. Two call
  sites, so it covers ordered pairing as well as resolution. Fails without the
  change.
- `test_mismatched_call_site_count_warns_and_falls_back` — asserts the
  `UserWarning` on a count mismatch.

### Notes

No behaviour change for `add_pytorch_module`: it converts the same program the
submodules were prepared from, so resolution returns the recorded names.
