### PR TITLE
Add experimental support for externalizing graphs to a separate artifact

### DIFF
--- a/coreai_torch/__init__.py
+++ b/coreai_torch/__init__.py
@@ -15,6 +15,7 @@ from torch import __version__ as _torch_version
 from .__version__ import __version__
 from ._composite_declaration import generate_composite_decl
 from ._decomp import get_decomp_table
+from ._experimental import _externalize_graphs
 from ._torch_metal_kernel import TorchMetalKernel
 from .converter import TorchConverter
 from .externalize import (
@@ -31,6 +32,7 @@ __all__ = [
     "TorchMetalKernel",
     "get_decomp_table",
     "generate_composite_decl",
+    "_externalize_graphs",
     "_patch_model_for_externalization",
     "_subexport_and_restore",
 ]

--- a/coreai_torch/_compression/utils.py
+++ b/coreai_torch/_compression/utils.py
@@ -158,19 +158,35 @@ def _inject_subbyte_in_lut(program: ExportedProgram) -> ExportedProgram:
                 indices = indices_args[0]
                 lut = lut_args[0]
                 indices_name = indices.name
+                passthrough = None
             elif node.args[0].name.startswith("ifp_constant") and node.args[
                 1
             ].name.startswith("ifp_constant"):
                 # we have some indirection of a ifp node hopefully
                 lut, indices = node.args[0:2]
                 indices_name = indices.args[0].name
+                passthrough = indices
             # The second last dimension or the last dimension of the lut tensor represents the number of palettes, which equals to 2**nbits, we get the
             # nbits from it. We update the annotation of uint8 in the indices
             # tensor to the corresponding torch data type, like torch.uint4
             # or torch.uint2 according to the inferred nbits.
-            # LUT shape is (..., num_palettes, cluster_dim), so num_palettes
-            # is always at shape[-2].
-            num_palettes = lut.meta["val"].shape[-2]
+            #
+            # The palette axis depends on the lut layout, so it is selected by rank:
+            # the wrong axis fails silently, packing indices at a plausible wrong nbits.
+            lut_shape = lut.meta["val"].shape
+            indices_val = indices.meta.get("val")
+            in_coreai_layout = (
+                indices_val is None or len(lut_shape) == indices_val.ndim + 2
+            )
+            num_palettes = lut_shape[-2 if in_coreai_layout else -1]
+
+            if num_palettes < 2 or num_palettes & (num_palettes - 1):
+                msg = (
+                    f"lut of shape {tuple(lut_shape)} for {node.target.name()} has "
+                    f"{num_palettes} palettes, which is not a power of two; the "
+                    f"palette count could not be located in this layout"
+                )
+                raise RuntimeError(msg)
             nbits = int(math.log2(num_palettes))
 
             if nbits not in PALETTIZATION_SUPPORT_NBITS:
@@ -190,6 +206,16 @@ def _inject_subbyte_in_lut(program: ExportedProgram) -> ExportedProgram:
                 program.state_dict[input_spec.target],
                 nbits,
             )
+
+            if passthrough is not None:
+                # The packed state dict makes the placeholder convert to ui<nbits>, but a
+                # custom op's fake kernel cannot carry a sub-byte dtype, so a node passing
+                # the indices through still claims uint8 and its lowering fails the result
+                # type check. Re-annotate it to match what the placeholder now converts to.
+                val = passthrough.meta["val"]
+                passthrough.meta["val"] = val.new_empty(
+                    val.shape, dtype=getattr(torch, f"uint{nbits}")
+                )
 
     graph.lint()
     return program

--- a/coreai_torch/_experimental/__init__.py
+++ b/coreai_torch/_experimental/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Experimental additions, with no backwards-compatibility guarantee.
+
+Everything here is underscore-prefixed on purpose and may change or disappear once a
+first-class equivalent exists.
+"""
+
+from ._delegate import (
+    module_instance_key,
+    outline_ops_into_graph,
+    wrap_ops_in_isolated_group,
+)
+from ._externalize_graphs import _externalize_graphs
+
+__all__ = [
+    "_externalize_graphs",
+    "module_instance_key",
+    "outline_ops_into_graph",
+    "wrap_ops_in_isolated_group",
+]

--- a/coreai_torch/_experimental/_delegate.py
+++ b/coreai_torch/_experimental/_delegate.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Group the ops one submodule contributed, once the graph body is built.
+
+Two groupings share the same machinery -- find the ops a matched module produced, work
+out what crosses their boundary, and move them somewhere:
+
+* :func:`wrap_ops_in_isolated_group` -> ``coreai.isolated_group<target>`` (delegation);
+* :func:`outline_ops_into_graph` -> a separate ``coreai.graph`` + ``coreai.invoke``
+  (externalization).
+
+Both are driven by naming an ``nn.Module`` class: every op ``nn_module_stack`` attributes
+to a matched instance is collected, and the run is moved somewhere as a unit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Container
+
+import coreai._compiler.dialects.coreai as coreai
+from coreai._compiler.ir import InsertionPoint, OpView, Value
+from torch.fx import Node
+
+__all__ = [
+    "module_instance_key",
+    "outline_ops_into_graph",
+    "wrap_ops_in_isolated_group",
+]
+
+_CONSTANT = "coreai.constant"
+
+
+def module_instance_key(
+    node: Node, targets: Container[str] | None = None
+) -> tuple[str, str] | None:
+    """``(module path, class name)`` for an FX node, or None if unattributed.
+
+    Keyed on the path as well as the class so that two instances of the same class get
+    one group each -- the legacy importer emitted one per call site, not one per class.
+
+    With ``targets``, the match is against the **outermost** enclosing module whose class
+    is named there, rather than the innermost. That is what makes a module with children
+    groupable: an adapter's projections are attributed to their own ``Linear``, so keying
+    on the leaf would give the adapter only the ops it performed *between* its children's
+    and report them, correctly, as non-contiguous. Matching an ancestor collects the
+    whole subtree, which is what "every op this module contributed" has to mean.
+    """
+    stack = node.meta.get("nn_module_stack")
+    if not stack:
+        return None
+    entries = [(str(path), str(cls).rsplit(".", 1)[-1]) for path, cls in stack.values()]
+    if targets is None:
+        return entries[-1]
+    return next((entry for entry in entries if entry[1] in targets), None)
+
+
+def _boundary_of(
+    ops: list[OpView],
+) -> tuple[list[OpView], list[Value], list[Value]]:
+    """What crosses the boundary of ``ops``: ``(constants, inputs, outputs)``.
+
+    ``inputs`` are values defined outside and used inside, ``outputs`` those defined
+    inside and used outside. ``constants`` are ``coreai.constant`` ops used *only* by
+    ``ops`` -- they come along rather than being passed in, which is what the legacy
+    groups look like (they carry their own tables instead of taking them as arguments).
+    """
+    inner = {op.operation for op in ops}
+    produced: set[Value] = {result for op in ops for result in op.results}
+
+    def is_inner(op: object) -> bool:
+        return getattr(op, "operation", op) in inner
+
+    constants: list[OpView] = []
+    seen_constants: set[object] = set()
+    inputs: list[Value] = []
+    for op in ops:
+        for operand in op.operands:
+            if operand in produced or operand in inputs:
+                continue
+            owner = operand.owner
+            if getattr(owner, "name", None) == _CONSTANT and all(
+                is_inner(use.owner) for use in operand.uses
+            ):
+                if owner.operation not in seen_constants:
+                    seen_constants.add(owner.operation)
+                    constants.append(owner)
+                produced.add(operand)
+                continue
+            inputs.append(operand)
+
+    outputs = [
+        result
+        for op in ops
+        for result in op.results
+        if any(not is_inner(use.owner) for use in result.uses)
+    ]
+    return constants, inputs, outputs
+
+
+def wrap_ops_in_isolated_group(
+    ops: list[OpView], target: str
+) -> tuple[OpView, dict[Value, Value]] | None:
+    """Move ``ops`` into an ``isolated_group<target>`` region, in place.
+
+    ``ops`` must be in block order and share a block. Returns ``(group, remap)`` where
+    ``remap`` maps each yielded inner value to the group result that replaced it outside
+    the region -- callers holding those values (e.g. a graph-output map) must follow it.
+    Returns None if ``ops`` is empty.
+
+    ``coreai.isolated_group`` is ``IsolatedFromAbove``, so nothing inside may reference
+    an outer value: every value defined outside and used inside becomes a region input.
+    The exception is a ``coreai.constant`` used *only* by ``ops`` -- that moves into the
+    region instead, so a group carries its own tables rather than taking them as
+    arguments.
+    """
+    if not ops:
+        return None
+
+    constants, inputs, outputs = _boundary_of(ops)
+    inner = {op.operation for op in ops}
+
+    def is_inner(op: object) -> bool:
+        return getattr(op, "operation", op) in inner
+
+    first = ops[0].operation
+    with first.context, first.location:
+        with InsertionPoint(first):
+            group = coreai.IsolatedGroupOp(
+                [value.type for value in outputs], inputs, target
+            )
+        region_block = group.regions[0].blocks.append(*[v.type for v in inputs])
+
+        # Constants first, so the region reads tables-then-compute.
+        for op in [*constants, *ops]:
+            region_block.append(op.operation)
+
+        remap = dict(zip(inputs, region_block.arguments))
+        for op in [*constants, *ops]:
+            for i, operand in enumerate(op.operands):
+                if operand in remap:
+                    op.operands[i] = remap[operand]
+
+        # Redirect the outside consumers *before* creating the yield, so the yield's own
+        # use of each value is not itself redirected.
+        for value, result in zip(outputs, group.results):
+            for use in list(value.uses):
+                if not is_inner(use.owner):
+                    use.owner.operands[use.operand_number] = result
+
+        with InsertionPoint(region_block):
+            coreai.yield_(outputs)
+
+    return group, dict(zip(outputs, group.results))
+
+
+def outline_ops_into_graph(
+    ops: list[OpView],
+    name: str,
+    *,
+    callee: str | None = None,
+    externalize: bool = True,
+) -> coreai.GraphOp | None:
+    """Move ``ops`` into a separate ``coreai.graph`` and call it instead, in place.
+
+    ``ops`` must be in block order and share a block. Returns the new graph, or None if
+    ``ops`` is empty. Consumers of the outlined values are re-pointed at the call, so a
+    parent graph whose output was one of them needs no further fixing up.
+
+    The boundary is wherever the ops happen to stop, and arguments are emitted unnamed:
+    attribution has no parameter names to draw on.
+
+    The graph lands at module top level. Pass ``callee`` when it will be moved into a
+    namespace afterwards, so the call names the qualified path it will need
+    (``"@ns::@inner::@name"``) rather than the flat symbol it has now.
+    """
+    if not ops:
+        return None
+
+    constants, inputs, outputs = _boundary_of(ops)
+    inner = {op.operation for op in ops}
+    first = ops[0].operation
+
+    module_op = first
+    while module_op.parent is not None:
+        module_op = module_op.parent
+    module_block = module_op.regions[0].blocks[0]
+
+    with first.context, first.location:
+        with InsertionPoint(module_block):
+            graph_op = coreai.GraphOp(
+                name=name,
+                input_types=[value.type for value in inputs],
+                result_types=[value.type for value in outputs],
+                loc=first.location,
+                no_inline=True,
+                externalize=externalize,
+            )
+
+        # The call takes the outlined ops' place, so it is built *before* they move --
+        # once they are gone there is nothing left in this block to anchor an insertion
+        # point to, and their operands have become block arguments.
+        with InsertionPoint(first):
+            results = coreai.invoke(
+                results=[value.type for value in outputs],
+                callee=callee if callee is not None else graph_op.symbol_name,
+                operands=inputs,
+                loc=first.location,
+            )
+
+        for value, result in zip(outputs, results):
+            for use in list(value.uses):
+                if use.owner.operation not in inner:
+                    use.owner.operands[use.operand_number] = result
+
+            # Constants first, so the body reads tables-then-compute.
+        for op in [*constants, *ops]:
+            graph_op.entry_block.append(op.operation)
+
+        remap = dict(zip(inputs, graph_op.arguments))
+        for op in [*constants, *ops]:
+            for i, operand in enumerate(op.operands):
+                if operand in remap:
+                    op.operands[i] = remap[operand]
+
+        with InsertionPoint(graph_op.entry_block):
+            coreai.output(outputs)
+
+    return graph_op

--- a/coreai_torch/_experimental/_externalize_graphs.py
+++ b/coreai_torch/_experimental/_externalize_graphs.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Splitting ``externalize``-marked graphs out of an :class:`AIProgram`."""
+
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from coreai._compiler._transforms.passes import (
+    CorePasses,
+    GlobalOptions,
+    PassEntry,
+    apply_passes_sync,
+)
+from coreai.authoring import AIProgram
+
+__all__ = ["_externalize_graphs"]
+
+
+def _externalize_graphs(program: AIProgram) -> AIProgram:
+    """Split the ``externalize``-marked graphs into their own :class:`AIProgram`.
+
+    Deep-copies first, so the source program survives and callers are order-independent:
+    the underlying pass mutates its module in place and ``AIProgram`` holds it by
+    reference. The ``externalize`` attribute is stripped from the graphs it keeps.
+    """
+    cloned = deepcopy(program)
+    # The pass writes nothing to disk for this pipeline, but GlobalOptions requires an
+    # output directory; a temporary one keeps it from touching the caller's cwd.
+    with TemporaryDirectory() as tmp:
+        apply_passes_sync(
+            cloned._mlir_module,  # noqa: SLF001
+            passes=[PassEntry.get(CorePasses.ISOLATE_EXTERNALIZED_GRAPHS)],
+            options=GlobalOptions(output_directory=Path(tmp)),
+        )
+    return cloned

--- a/coreai_torch/_utils.py
+++ b/coreai_torch/_utils.py
@@ -869,7 +869,8 @@ def process_indices_with_transpose(
     target_rank = len(broadcast_shape)
     # Use static list for known shapes; use runtime broadcast_shapes for dynamic dims.
     # (coreai.constant([-1]) would produce UINT32_MAX after si32→ui32 cast.)
-    if not any(d < 0 for d in broadcast_shape):
+    static_shape = not any(d < 0 for d in broadcast_shape)
+    if static_shape:
         shape_arg: list[int] | Value = broadcast_shape
     else:
         # Compute broadcast shape at runtime via coreai.broadcast_shapes.
@@ -878,16 +879,38 @@ def process_indices_with_transpose(
         for s in shape_tensors[1:]:
             shape_arg = coreai.broadcast_shapes(shape_arg, s, loc=loc)
 
-    broadcasted = [
-        coreai.broadcast_to(
+    broadcasted = []
+    for idx in non_none_indices:
+        aligned_idx = (
             coreai.expand_dims(idx, list(range(target_rank - idx.type.rank)), loc=loc)
             if idx.type.rank < target_rank
-            else idx,
-            shape_arg,
-            loc=loc,
+            else idx
         )
-        for idx in non_none_indices
-    ]
+        if static_shape:
+            # `shape_arg` is a constant list, so inference already recovers every dim.
+            broadcasted.append(coreai.broadcast_to(aligned_idx, shape_arg, loc=loc))
+            continue
+        # Dynamic: `shape_arg` is a runtime value that inference cannot look through, so
+        # it drops *every* dim -- including ones known statically here. Indexing with two
+        # (1, S) tensors would come out (?, ?) instead of (1, ?), and that loss propagates
+        # through the gather into the enclosing graph's signature. Type it from the shape
+        # computed above instead.
+        broadcasted.append(
+            coreai.BroadcastToOp(
+                aligned_idx,
+                shape_arg,
+                results=[
+                    RankedTensorType.get(
+                        [
+                            d if d >= 0 else RankedTensorType.get_dynamic_size()
+                            for d in broadcast_shape
+                        ],
+                        idx.type.element_type,
+                    )
+                ],
+                loc=loc,
+            ).result
+        )
 
     # Reattach None slots.
     it = iter(broadcasted)

--- a/coreai_torch/converter.py
+++ b/coreai_torch/converter.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Optional, cast
@@ -23,7 +24,9 @@ from coreai._compiler.ir import (
     InsertionPoint,
     Location,
     Module,
+    Operation,
     OpResultList,
+    OpView,
     StringAttr,
     Type,
     Value,
@@ -41,6 +44,11 @@ from ._composite_declaration import generate_composite_decl
 from ._compression.utils import inject_subbyte_tensors
 from ._custom_to_core import _custom_to_core_resolver
 from ._debug_locations import _DebugInfoRecorder
+from ._experimental._delegate import (
+    module_instance_key,
+    outline_ops_into_graph,
+    wrap_ops_in_isolated_group,
+)
 from ._torch_metal_kernel import TorchMetalKernel
 from ._utils import (
     _NARROW_TORCH_DTYPE,
@@ -155,6 +163,12 @@ class TorchConverter:
 
         # user defined torch op lowering (reusable across conversions)
         self._user_defined_torch_lowering: dict[str, Callable[..., Any]] = {}
+        self._delegate_ids: dict[str, str] = {}
+        self._entrypoint_delegate_ids: dict[str, str] = {}
+        self._externalize_groups: dict[str, str | Callable[[str], str]] = {}
+        self._externalize_group_marks: dict[str, bool] = {}
+        self._externalize_name_map: dict[str, str] = {}
+        self._matched_externalize_groups: set[str] = set()
 
         # staged programs awaiting conversion
         self._staged: list[_StagedEntry] = []
@@ -307,6 +321,142 @@ class TorchConverter:
         )
         return self
 
+    def _set_delegate_id(self: Self, module_class_name: str, target: str) -> Self:
+        """Run every instance of ``module_class_name`` on ``target``.
+
+        Wraps the ops each matched submodule contributed in ``coreai.isolated_group<target>``
+        once the graph body is built. Matched by leaf class name from ``nn_module_stack``,
+        one region per instance; a non-contiguous instance is skipped with a warning.
+        """
+        self._delegate_ids[module_class_name] = target
+        return self
+
+    def _set_entrypoint_delegate_id(
+        self: Self, entrypoint_name: str, target: str
+    ) -> Self:
+        """Run a whole procedure on ``target``.
+
+        Wraps the entire graph body in ``coreai.isolated_group<target>``, rather than the ops
+        one module class contributed. Placement is sometimes a property of the procedure and
+        not of any module inside it, and attribution cannot express that: a body that is a
+        single constant has no attributed op to match, and a module whose work is all done by
+        children owns none of the resulting ops.
+        """
+        self._entrypoint_delegate_ids[entrypoint_name] = target
+        return self
+
+    def _apply_delegate_ids(
+        self,
+        all_ops: list[OpView],
+        spans: dict[tuple[str, str], list[tuple[int, int]]],
+    ) -> None:
+        """Wrap each delegated instance's ops in an isolated_group.
+
+        ``spans`` gives the ``[start, end)`` op-index ranges each instance contributed,
+        indexing ``all_ops``. Non-contiguous ranges are skipped: the ops in between belong
+        to another module, and pulling them in would reorder unrelated computation.
+        """
+        for (path, cls), ranges in sorted(spans.items()):
+            start, end = ranges[0][0], ranges[-1][1]
+            if end - start != sum(hi - lo for lo, hi in ranges):
+                warnings.warn(
+                    f"_set_delegate_id({cls!r}): the ops for instance {path!r} are not "
+                    f"contiguous, so it was not delegated to "
+                    f"{self._delegate_ids[cls]!r}. This happens when another module's ops "
+                    f"are interleaved with it, including a nested delegated submodule.",
+                    stacklevel=2,
+                )
+                continue
+            wrap_ops_in_isolated_group(all_ops[start:end], self._delegate_ids[cls])
+
+    def _set_externalize_group(
+        self: Self,
+        module_class_name: str,
+        namespace: str | Callable[[str], str],
+        *,
+        externalize: bool = True,
+    ) -> Self:
+        """Externalize every instance of ``module_class_name`` into ``namespace``.
+
+        Each matched submodule's ops move into their own ``coreai.graph`` (marked
+        ``externalize``, inside ``namespace``) and are replaced by a ``coreai.invoke``.
+        ``externalize=False`` outlines a plain ``noinline`` graph, which resolves in-asset.
+        """
+        self._externalize_groups[module_class_name] = namespace
+        self._externalize_group_marks[module_class_name] = externalize
+        return self
+
+    def _set_externalize_name_map(self: Self, name_map: Mapping[str, str]) -> Self:
+        """Pin outlined graph names: ``{module path as traced: name to emit}``.
+
+        Graphs are named after the traced ``nn_module_stack`` path, so a procedure traced
+        after the module tree is restructured emits names an earlier procedure will not
+        match. Entries matching nothing are ignored. Returns ``self`` for chaining.
+        """
+        self._externalize_name_map.update(name_map)
+        return self
+
+    def _apply_externalize_groups(
+        self,
+        all_ops: list[OpView],
+        spans: dict[tuple[str, str], list[tuple[int, int]]],
+        entrypoint: str,
+    ) -> None:
+        """Outline each matched instance's ops into its own graph.
+
+        ``spans`` gives the ``[start, end)`` op-index ranges each instance contributed,
+        indexing ``all_ops``; see :meth:`_apply_delegate_ids` for why non-contiguous
+        instances cannot be grouped.
+        """
+        outlined: list[tuple[str, str, int, int]] = []
+        for (path, cls), ranges in sorted(spans.items()):
+            start, end = ranges[0][0], ranges[-1][1]
+            if end - start != sum(hi - lo for lo, hi in ranges):
+                warnings.warn(
+                    f"_set_externalize_group({cls!r}): the ops for instance {path!r} are "
+                    f"not contiguous, so it was not externalized into "
+                    f"{self._externalize_groups[cls]!r}. This happens when another "
+                    f"module's ops are interleaved with it.",
+                    stacklevel=2,
+                )
+                continue
+            outlined.append((path, cls, start, end))
+            self._matched_externalize_groups.add(cls)
+
+        for path, cls, start, end in outlined:
+            spec = self._externalize_groups[cls]
+            namespace = spec(entrypoint) if callable(spec) else spec
+            name = self._externalize_name_map.get(path, path)
+            graph = outline_ops_into_graph(
+                all_ops[start:end],
+                name,
+                callee="::@".join(namespace.split(".") + [name]),
+                externalize=self._externalize_group_marks.get(cls, True),
+            )
+            if graph is not None:
+                self._nest_graph_op(graph, namespace)
+
+    def _warn_unmatched_externalize_groups(self) -> None:
+        """Report classes registered for outlining that no op was attributed to.
+
+        ``nn_module_stack`` only records a module entered via ``__call__``, so a wrapper
+        delegating with ``self.inner.forward(...)`` keeps ``inner`` out of it -- and
+        conversion then succeeds while silently producing nothing.
+        """
+        unmatched = sorted(
+            set(self._externalize_groups) - self._matched_externalize_groups
+        )
+        if not unmatched:
+            return
+        warnings.warn(
+            f"_set_externalize_group: no ops were attributed to the following "
+            f"class(es), so nothing was externalized for them: {', '.join(unmatched)}. "
+            f"Check the class name, and that the module is invoked as `module(...)` "
+            f"rather than `module.forward(...)` -- only the former is recorded in "
+            f"nn_module_stack.",
+            stacklevel=2,
+        )
+
     def _run_externalize_pipeline_from_module(self) -> None:
         """Externalize from a live ``nn.Module`` + ``export_fn`` (Phases 1-3).
 
@@ -415,6 +565,45 @@ class TorchConverter:
         # asset. Left in, a model with three blocks reported Block$2, Block$3 and
         # Block$4, with no Block$1 anywhere.
         self._debug_info_recorder.reset_module_registry()
+
+    @staticmethod
+    def _nest_graph_op(graph_op: coreai.GraphOp, namespace: str) -> None:
+        """Move ``graph_op`` into nested symbol tables named by a dotted ``namespace``.
+
+        ``"a.b"`` gives ``udml.namespace @a { namespace @b { <graph> }}``, which is what
+        makes ``@a::@b::@<name>`` resolve; existing levels are reused. Not a nested
+        ``builtin.module``: that verifies in memory but is not serializable.
+        """
+        parent_block = graph_op.operation.parent.regions[0].blocks[0]
+        for level in namespace.split("."):
+            existing = None
+            for op in parent_block.operations:
+                if (
+                    op.operation.name == "udml.namespace"
+                    and "sym_name" in op.operation.attributes
+                    and StringAttr(op.operation.attributes["sym_name"]).value == level
+                ):
+                    existing = op
+                    break
+            if existing is None:
+                with InsertionPoint.at_block_begin(parent_block):
+                    # Carry the graph's own location. Without an explicit one the op
+                    # picks up whatever is ambient, which can be an unrepresentable
+                    # file location -- bytecode serialization then fails with
+                    #   Failed to serialize module to Bytecode: at
+                    #   #aicode.debuginfo.location_v1<src = <file = <filename = "-" ...
+                    # reported against this very module op.
+                    existing = Operation.create(
+                        "udml.namespace",
+                        attributes={"sym_name": StringAttr.get(level)},
+                        regions=1,
+                        loc=graph_op.location,
+                    )
+                existing.regions[0].blocks.append()
+            parent_block = existing.regions[0].blocks[0]
+
+        graph_op.operation.detach_from_parent()
+        parent_block.append(graph_op.operation)
 
     def _clean(self) -> None:
         """Reset all internal state dictionaries to empty.
@@ -828,13 +1017,50 @@ class TorchConverter:
             description = (
                 f"Converting {name}" if primary_entrypoint else "Converting submodule"
             )
+            delegate_spans: dict[tuple[str, str], list[tuple[int, int]]] = {}
+            group_spans: dict[tuple[str, str], list[tuple[int, int]]] = {}
             for node in self._progress_bar.track(
                 graph_module.graph.nodes,
                 description=description,
                 transient=not primary_entrypoint,
             ):
+                # Resolve attribution *before* converting: it only reads `node.meta`, while
+                # `len(block.operations)` walks the whole block. Measuring every node made
+                # conversion quadratic in graph size; only a node that belongs to a
+                # registered class needs its op span.
+                delegate_key: tuple[str, str] | None = None
+                group_key: tuple[str, str] | None = None
+                if self._delegate_ids:
+                    # Delegation keys on the leaf, externalization on the outermost match
+                    # -- see `module_instance_key`. A delegated module is a placement hint
+                    # for the ops it performed itself; an externalized one is a callable
+                    # boundary, so it has to take its children with it.
+                    leaf = module_instance_key(node)
+                    if leaf is not None and leaf[1] in self._delegate_ids:
+                        delegate_key = leaf
+                if self._externalize_groups:
+                    group_key = module_instance_key(node, self._externalize_groups)
+                measure = delegate_key is not None or group_key is not None
+
+                before = len(graph_op.entry_block.operations) if measure else 0
                 with graph_op.block:
                     self._get_operation(node)
+                if measure:
+                    after = len(graph_op.entry_block.operations)
+                    if after > before:
+                        if delegate_key is not None:
+                            delegate_spans.setdefault(delegate_key, []).append(
+                                (before, after)
+                            )
+                        if group_key is not None:
+                            group_spans.setdefault(group_key, []).append(
+                                (before, after)
+                            )
+
+            # Operation IDs and debug locations for everything just lowered, in one IR-order
+            # pass. Must precede the grouping rewrites below: those move operations into
+            # their own regions or graphs, out of reach of this graph's walk.
+            self._debug_info_recorder.finalize_node_operations()
 
             # Operation IDs and debug locations for everything just lowered, in one
             # IR-order pass, now that the graph body is complete.
@@ -880,6 +1106,31 @@ class TorchConverter:
                     )
                 arg_attr.append(DictAttr.get(attr_dict))
             graph_op.arg_attrs = ArrayAttr.get(arg_attr)
+
+            # After the terminator exists: a value consumed only by `coreai.output`
+            # must still be yielded out of the region.
+            if delegate_spans or (group_spans and primary_entrypoint):
+                # One snapshot for both groupings. The spans are op *indices* recorded
+                # while the block was being built, so they are only valid against the
+                # block as the loop left it -- and each grouping mutates it, replacing a
+                # run of ops with a single region or call. Resolving to op handles up
+                # front makes the two independent of each other's edits and of order.
+                all_ops = list(graph_op.entry_block.operations)
+                if delegate_spans:
+                    self._apply_delegate_ids(all_ops, delegate_spans)
+                if group_spans and primary_entrypoint:
+                    self._apply_externalize_groups(all_ops, group_spans, name)
+
+            target = self._entrypoint_delegate_ids.get(name)
+            if target is not None and primary_entrypoint:
+                # Everything except the terminator, which has to stay in the graph body.
+                body = [
+                    op
+                    for op in graph_op.entry_block.operations
+                    if op.name != "coreai.output"
+                ]
+                if body:
+                    wrap_ops_in_isolated_group(body, target)
 
         return graph_op
 
@@ -948,6 +1199,7 @@ class TorchConverter:
                             entry.entrypoint_name, primary_entrypoint=True
                         )
 
+        self._warn_unmatched_externalize_groups()
         return AIProgram._from_mlir_module(module)
 
     def clear(self, *, entrypoints: Sequence[str] | None = None) -> None:

--- a/coreai_torch/externalize.py
+++ b/coreai_torch/externalize.py
@@ -298,7 +298,7 @@ def _prepare_module(
     op_name = f"{_sanitize_op_name(name)}_{op_name_suffix}"
     qualified_name = f"{_EXTERNALIZE_NAMESPACE}::{op_name}"
 
-    if hasattr(submodule, "_original_forward"):
+    if "_original_forward" in submodule.__dict__:
         raise RuntimeError(
             f"submodule '{name}' is already marked for externalization "
             f"(missing a restore from a prior _patch_model_for_externalization call). "
@@ -463,10 +463,16 @@ def _find_marked_submodules(model: torch.nn.Module) -> list[torch.nn.Module]:
     them, so ``_subexport_and_restore`` rediscovers them this way each time
     it runs.
     """
+    # `__dict__` rather than `hasattr`: a wrapper module that delegates unknown
+    # attributes to a child (a common way to give a submodule a distinct class) would
+    # otherwise report its marked child's stamps as its own, and get "restored" -- a
+    # module that was never patched, whose stamps cannot be deleted because they are
+    # not on it. The stamps are always set through `__setattr__`, so they are always
+    # in the instance dict of the module that owns them.
     return [
         mod
         for name, mod in model.named_modules()
-        if name and hasattr(mod, "_externalize_name")
+        if name and "_externalize_name" in mod.__dict__
     ]
 
 
@@ -743,11 +749,11 @@ def _restore_externalized(marked: list[torch.nn.Module]) -> None:
     Called after the pipeline completes (or on error via ``finally``).
     """
     for mod in marked:
-        original = getattr(mod, "_original_forward", None)
+        original = mod.__dict__.get("_original_forward")
         if original is not None:
             mod.forward = original
             del mod._original_forward
             del mod._externalize_name
             del mod._externalize_op_name
-            if hasattr(mod, "_externalize_config"):
+            if "_externalize_config" in mod.__dict__:
                 del mod._externalize_config

--- a/tests/compression/test_custom_layers.py
+++ b/tests/compression/test_custom_layers.py
@@ -18,7 +18,10 @@ from coreai_torch._compression.custom_layers import (
     quantize,
     sparse_to_dense,
 )
-from coreai_torch._compression.utils import _inject_subbyte_in_quant
+from coreai_torch._compression.utils import (
+    _inject_subbyte_in_lut,
+    _inject_subbyte_in_quant,
+)
 
 # ──────────────────────────────────────────────────────────────────────
 # constexpr_blockwise_shift_scale
@@ -585,6 +588,140 @@ def test_inject_subbyte_uses_input_dtype_arg(
     else:
         # nbits == 8 means no conversion (CHAR_BIT check skips it).
         assert not isinstance(converted, SubbyteTensor)
+
+
+@torch.library.custom_op("coreai_torch_test::lut_to_dense", mutates_args=())
+def _flat_lut_to_dense(lut: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    """A foreign `lut_to_dense` with a flat lut and `coreai`'s operands reversed.
+
+    Models a downstream op (tamm-export has one) whose lut is
+    ``(num_blocks, num_palettes)`` and which reshapes to the ``coreai`` layout in its
+    own lowering rather than up front.
+    """
+    return lut.new_zeros(indices.shape)
+
+
+@_flat_lut_to_dense.register_fake
+def _(lut: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    return lut.new_empty(indices.shape)
+
+
+def _export_flat_lut_model(
+    num_blocks: int, num_palettes: int, out_channels: int = 32
+) -> torch.export.ExportedProgram:
+    """Export a model calling the flat-lut op on conv2d-shaped (rank-4) indices."""
+    indices_shape = (out_channels, 8, 1, 1)
+
+    class Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer(
+                "palettized_indices",
+                torch.randint(0, num_palettes, indices_shape, dtype=torch.uint8),
+            )
+            self.register_buffer(
+                "palettized_lut",
+                torch.randn(num_blocks, num_palettes, dtype=torch.float16),
+            )
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            weight = torch.ops.coreai_torch_test.lut_to_dense(
+                self.palettized_lut, self.palettized_indices
+            )
+            return x + weight
+
+    model = Model().eval()
+    with torch.no_grad():
+        return torch.export.export(
+            model, (torch.randn(indices_shape, dtype=torch.float16),)
+        )
+
+
+@pytest.mark.parametrize(
+    ("num_blocks", "num_palettes", "expected_nbits"),
+    [
+        # Block counts taken from a real 4-bit palettized model (out_channels / 16).
+        # Read at shape[-2] these gave 7 (raised), 6 (silently wrong) and 4 (right
+        # only by coincidence, both axes being 16) respectively.
+        pytest.param(200, 16, 4, id="200_blocks_was_7bit_error"),
+        pytest.param(64, 16, 4, id="64_blocks_was_silently_6bit"),
+        pytest.param(16, 16, 4, id="16_blocks_ambiguous"),
+        pytest.param(64, 4, 2, id="2bit"),
+    ],
+)
+def test_inject_subbyte_in_lut_flat_layout_uses_last_dim(
+    num_blocks: int, num_palettes: int, expected_nbits: int
+) -> None:
+    """A flat (num_blocks, num_palettes) lut must take its palette count from shape[-1].
+
+    The lut is rank 2 against rank-4 indices, so it is *not* in the coreai layout
+    (which would be rank 4 + 2 = 6) and shape[-2] is the block count.
+    """
+    program = _inject_subbyte_in_lut(_export_flat_lut_model(num_blocks, num_palettes))
+
+    indices_key = next(k for k in program.state_dict if "palettized_indices" in k)
+    converted = program.state_dict[indices_key]
+
+    assert isinstance(converted, SubbyteTensor), (
+        f"indices were not narrowed for a {num_palettes}-palette lut; "
+        f"got {type(converted)}"
+    )
+    assert converted.nbits == expected_nbits, (
+        f"lut of shape ({num_blocks}, {num_palettes}) inferred "
+        f"{converted.nbits}-bit, expected {expected_nbits}-bit -- the palette count "
+        f"was read off the wrong axis"
+    )
+
+
+# 3 is in PALETTIZATION_SUPPORT_NBITS but `UintxTensor.from_unpacked` only handles
+# 1/2/4/6, so a 3-bit lut fails in the packing step for reasons unrelated to the axis
+# choice under test here; 8 is skipped outright by the CHAR_BIT check.
+@pytest.mark.parametrize("nbits", [1, 2, 4, 6])
+def test_inject_subbyte_in_lut_coreai_layout_uses_second_last_dim(nbits: int) -> None:
+    """`coreai::lut_to_dense`'s own layout must still resolve at shape[-2].
+
+    Here `lut` is rank `indices.rank + 2` with the palette count at shape[-2] and a
+    vector size at shape[-1], so keying off rank has to pick the second-last axis --
+    shape[-1] would give a vector size of 1 and a nonsensical 0 bits.
+    """
+    indices_shape = (2, 3)
+    vector_size = 4
+
+    class Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer(
+                "indices",
+                torch.randint(0, 2**nbits, indices_shape, dtype=torch.uint8),
+            )
+            self.register_buffer(
+                "lut",
+                torch.randn(1, 1, 2**nbits, vector_size, dtype=torch.float16),
+            )
+
+        def forward(self) -> torch.Tensor:
+            return torch.ops.coreai.lut_to_dense(self.indices, self.lut, 0)
+
+    model = Model().eval()
+    with torch.no_grad():
+        program = torch.export.export(model, ())
+
+    program = _inject_subbyte_in_lut(program)
+
+    indices_key = next(k for k in program.state_dict if "indices" in k)
+    converted = program.state_dict[indices_key]
+    assert isinstance(converted, SubbyteTensor)
+    assert converted.nbits == nbits
+
+
+def test_inject_subbyte_in_lut_rejects_non_power_of_two_palette_count() -> None:
+    """A count that is not 2**nbits must raise, not reach log2.
+
+    Without the check, `log2(12)` truncates to 3 and the indices are packed at a
+    width the lut cannot address -- a silent miscompression rather than an error.
+    """
+    with pytest.raises(RuntimeError, match="not a power of two"):
+        _inject_subbyte_in_lut(_export_flat_lut_model(4, 12))
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/compression/test_subbyte_lut_indirection.py
+++ b/tests/compression/test_subbyte_lut_indirection.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for sub-byte lut indices reached through a pass-through op.
+
+A palettized model may not hand its indices to ``lut_to_dense`` directly: IFP routes them
+through a placeholder op that carries slot metadata. ``_inject_subbyte_in_lut`` packs the
+indices in the state dict, which makes the *placeholder* convert to ``ui<nbits>``, so any
+op passing them through has to be re-annotated to agree -- a custom op's fake kernel can
+only say ``uint8``, and the converter's result type check rejects the mismatch.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+import coreai_torch._compression.custom_layers  # noqa: F401  (registers coreai::lut_to_dense)
+from coreai_torch._compression.utils import _inject_subbyte_in_lut
+
+
+@torch.library.custom_op("test_subbyte_lut::ifp_constant_hint", mutates_args=())
+def ifp_constant_hint(c_input: torch.Tensor) -> torch.Tensor:
+    """Pass the input through, standing in for IFP's metadata-carrying placeholder."""
+    return c_input.clone()
+
+
+@ifp_constant_hint.register_fake  # type: ignore[misc]
+def _(c_input: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(c_input)
+
+
+@torch.library.custom_op("test_subbyte_lut::stand_in_lut_to_dense", mutates_args=())
+def stand_in_lut_to_dense(lut: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    """``(lut, indices)`` order, as ``tamm_export::lut_to_dense`` declares it."""
+    return torch.zeros(indices.shape, dtype=lut.dtype)
+
+
+@stand_in_lut_to_dense.register_fake  # type: ignore[misc]
+def _(lut: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    return torch.zeros(indices.shape, dtype=lut.dtype)
+
+
+class _IndirectPalettizedModel(nn.Module):
+    """Both lut and indices reach the lut op through a pass-through placeholder."""
+
+    def __init__(self, nbits: int) -> None:
+        super().__init__()
+        # The palette count sits at lut.shape[-2], and the layout is recognised by rank:
+        # lut.ndim == indices.ndim + 2.
+        self.register_buffer(
+            "palettized_lut",
+            torch.ones((1, 1, 2**nbits, 2), dtype=torch.float16),
+        )
+        self.register_buffer(
+            "palettized_indices",
+            torch.randint(0, 2**nbits, (8, 4), dtype=torch.uint8),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        lut = torch.ops.test_subbyte_lut.ifp_constant_hint(self.palettized_lut)
+        indices = torch.ops.test_subbyte_lut.ifp_constant_hint(self.palettized_indices)
+        dense = torch.ops.test_subbyte_lut.stand_in_lut_to_dense(lut, indices)
+        return dense + x
+
+
+def _nodes_by_op(program: torch.export.ExportedProgram, op_name: str) -> list:
+    return [
+        node
+        for node in program.graph.nodes
+        if node.op == "call_function"
+        and hasattr(node.target, "name")
+        and node.target.name().endswith(op_name)
+    ]
+
+
+@pytest.mark.parametrize("nbits", [2, 4])
+def test_passthrough_indices_are_reannotated_to_the_packed_dtype(nbits: int) -> None:
+    """The op passing the indices through reports ``ui<nbits>``, matching the placeholder.
+
+    Without this the pass-through node keeps torch's ``uint8`` while the placeholder it
+    reads converts to ``ui<nbits>``, and lowering the pass-through fails with
+    ``dtype ui2 vs ui8``.
+    """
+    model = _IndirectPalettizedModel(nbits).eval()
+    program = torch.export.export(model, (torch.zeros((8, 4), dtype=torch.float16),))
+
+    hints = _nodes_by_op(program, "ifp_constant_hint")
+    assert len(hints) == 2, (
+        "expected one pass-through for the lut and one for the indices"
+    )
+    lut_hint, indices_hint = hints
+    assert indices_hint.meta["val"].dtype == torch.uint8, (
+        "precondition: torch says uint8"
+    )
+
+    _inject_subbyte_in_lut(program)
+
+    expected = getattr(torch, f"uint{nbits}")
+    assert indices_hint.meta["val"].dtype == expected
+    # Shape is preserved: only the element type is restated.
+    assert tuple(indices_hint.meta["val"].shape) == (8, 4)
+    # The lut is not indices; re-annotating it would corrupt the palette table.
+    assert lut_hint.meta["val"].dtype == torch.float16
+
+
+@pytest.mark.parametrize("nbits", [2, 4])
+def test_indices_are_packed_in_the_state_dict(nbits: int) -> None:
+    """The indices buffer is repacked, which is what makes the placeholder ui<nbits>."""
+    model = _IndirectPalettizedModel(nbits).eval()
+    program = torch.export.export(model, (torch.zeros((8, 4), dtype=torch.float16),))
+
+    _inject_subbyte_in_lut(program)
+
+    packed = program.state_dict["palettized_indices"]
+    assert packed.dtype == getattr(torch, f"uint{nbits}")
+    assert program.state_dict["palettized_lut"].dtype == torch.float16
+
+
+def test_directly_wired_lut_indices_are_left_alone() -> None:
+    """With no pass-through there is nothing to re-annotate, and nothing is touched.
+
+    ``coreai::lut_to_dense`` takes its operands by name, so this is the common path; the
+    re-annotation must not reach into it.
+    """
+
+    class DirectModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer(
+                "indices", torch.randint(0, 4, (2, 3), dtype=torch.uint8)
+            )
+            self.register_buffer("lut", torch.ones((1, 1, 4, 1), dtype=torch.float16))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            dense = torch.ops.coreai.lut_to_dense(
+                indices=self.indices, lut=self.lut, axis=0
+            )
+            return dense + x
+
+    model = DirectModel().eval()
+    program = torch.export.export(model, (torch.zeros((2, 3), dtype=torch.float16),))
+
+    _inject_subbyte_in_lut(program)
+
+    # 4 palettes -> 2 bits, applied to the state dict as before.
+    assert program.state_dict["indices"].dtype == torch.uint2

--- a/tests/experimental/__init__.py
+++ b/tests/experimental/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for `coreai_torch._experimental`."""

--- a/tests/experimental/test_delegate_id.py
+++ b/tests/experimental/test_delegate_id.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Tests for ``TorchConverter._set_delegate_id``.
+
+Pin every instance of a module class to a backend, by wrapping the ops it contributed in
+``coreai.isolated_group<target>``.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+import torch
+import torch.nn as nn
+from coreai.runtime import NDArray
+
+from coreai_torch import TorchConverter, get_decomp_table
+
+from ..utils import compare_outputs
+
+TABLE_ROWS = 16
+TABLE_COLS = 4
+
+
+class Lookup(nn.Module):
+    """A gather off a constant table -- the shape of the RoPE/embedding lookups."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer(
+            "table",
+            torch.arange(TABLE_ROWS * TABLE_COLS, dtype=torch.float32).reshape(
+                TABLE_ROWS, TABLE_COLS
+            ),
+            persistent=False,
+        )
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.table[idx.to(torch.int32)]
+
+
+class Scale(nn.Module):
+    def __init__(self, factor: float) -> None:
+        super().__init__()
+        self.factor = factor
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.factor
+
+
+class Net(nn.Module):
+    """`lookup` feeds the tail, so its ops are contiguous and its result is consumed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lookup = Lookup()
+
+    def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+        return x + self.lookup(idx).sum(-1, keepdim=True)
+
+
+class TwoLookups(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first = Lookup()
+        self.second = Lookup()
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.first(idx).sum(-1) + self.second(idx).sum(-1)
+
+
+class LookupOnly(nn.Module):
+    """The delegated module produces the graph output directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lookup = Lookup()
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.lookup(idx)
+
+
+class Nested(nn.Module):
+    """A delegated module containing another delegated module."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lookup = Lookup()
+        self.scale = Scale(2.0)
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.scale(self.lookup(idx)) + 1.0
+
+
+class Straddle(nn.Module):
+    """Own ops on both sides of a submodule's, so its span is broken."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = Lookup()
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.inner(idx + 1) * 2.0
+
+
+class OuterStraddle(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.straddle = Straddle()
+
+    def forward(self, idx: torch.Tensor) -> torch.Tensor:
+        return self.straddle(idx)
+
+
+IDX = torch.zeros(2, dtype=torch.int64)
+X = torch.ones(2, 1)
+
+
+def _convert(model: nn.Module, args: tuple, delegates: dict[str, str] | None = None):
+    """Export + convert, optionally with delegate ids set. Returns the AIProgram."""
+    ep = torch.export.export(model, args).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    for cls, target in (delegates or {}).items():
+        converter._set_delegate_id(cls, target)
+    converter.add_exported_program(ep, entrypoint_name="main")
+    return converter.to_coreai()
+
+
+def _verify(program) -> None:
+    """The invariant every case must hold: the module still verifies."""
+    program._mlir_module.operation.verify()
+
+
+def _region_of(ir: str, target: str) -> str:
+    """The text of the first isolated_group region for `target`."""
+    marker = f'isolated_group<"{target}">'
+    assert marker in ir, f"no {marker} in:\n{ir}"
+    start = ir.index(marker)
+    depth, i = 0, ir.index("{", start)
+    for j in range(i, len(ir)):
+        if ir[j] == "{":
+            depth += 1
+        elif ir[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return ir[i : j + 1]
+    raise AssertionError("unbalanced region")
+
+
+def test_wraps_matched_module_in_isolated_group() -> None:
+    program = _convert(Net(), (X, IDX), {"Lookup": "Interpreter"})
+    ir = str(program)
+    assert ir.count('coreai.isolated_group<"Interpreter">') == 1
+    _verify(program)
+
+
+def test_no_delegate_id_emits_no_region() -> None:
+    """Opt-in: without the call, conversion is untouched."""
+    ir = str(_convert(Net(), (X, IDX)))
+    assert "isolated_group" not in ir
+
+
+def test_delegated_ops_move_into_the_region() -> None:
+    """The gather belongs to Lookup, the reduce/add to Net."""
+    ir = str(_convert(Net(), (X, IDX), {"Lookup": "Interpreter"}))
+    region = _region_of(ir, "Interpreter")
+    assert "coreai.gather_nd" in region
+    assert "reduce_sum" not in region
+    assert "broadcasting_add" not in region
+
+
+def test_constant_used_only_inside_is_pulled_in() -> None:
+    """A region carries its own tables rather than taking them as arguments."""
+    ir = str(_convert(Net(), (X, IDX), {"Lookup": "Interpreter"}))
+    region = _region_of(ir, "Interpreter")
+    # the table constant lives inside...
+    assert f"tensor<{TABLE_ROWS}x{TABLE_COLS}xf32>" in region
+    # ...and the group therefore takes a single operand: the index
+    header = ir[ir.index('isolated_group<"Interpreter">') :].split("{")[0]
+    assert header.count("%arg") == 1, header
+
+
+def test_only_externally_used_results_are_yielded() -> None:
+    ir = str(_convert(Net(), (X, IDX), {"Lookup": "Interpreter"}))
+    region = _region_of(ir, "Interpreter")
+    yields = [ln for ln in region.splitlines() if "coreai.yield" in ln]
+    assert len(yields) == 1
+    assert yields[0].count(",") == 0, f"expected one yielded value: {yields[0]}"
+
+
+def test_one_region_per_instance_not_per_class() -> None:
+    """Two instances of the class must give two regions, not one per class."""
+    program = _convert(TwoLookups(), (IDX,), {"Lookup": "Interpreter"})
+    assert str(program).count('coreai.isolated_group<"Interpreter">') == 2
+    _verify(program)
+
+
+def test_delegated_module_producing_the_graph_output() -> None:
+    """The output spec must follow the region's result, not the value now inside it."""
+    program = _convert(LookupOnly(), (IDX,), {"Lookup": "Interpreter"})
+    ir = str(program)
+    assert ir.count('coreai.isolated_group<"Interpreter">') == 1
+    _verify(program)
+    # the graph output is the group's result
+    output_line = next(ln for ln in ir.splitlines() if "coreai.output" in ln)
+    group_result = next(
+        ln.split("=")[0].strip()
+        for ln in ir.splitlines()
+        if 'isolated_group<"Interpreter">' in ln
+    )
+    assert group_result in output_line, f"{group_result!r} not in {output_line!r}"
+
+
+def test_distinct_targets_for_distinct_classes() -> None:
+    program = _convert(Nested(), (IDX,), {"Lookup": "Interpreter", "Scale": "CPU"})
+    ir = str(program)
+    assert ir.count('coreai.isolated_group<"Interpreter">') == 1
+    assert ir.count('coreai.isolated_group<"CPU">') == 1
+    _verify(program)
+
+
+def test_unmatched_class_name_is_a_noop() -> None:
+    program = _convert(Net(), (X, IDX), {"NoSuchModule": "Interpreter"})
+    assert "isolated_group" not in str(program)
+    _verify(program)
+
+
+def test_non_contiguous_module_is_skipped_with_warning() -> None:
+    """A module whose ops straddle a submodule's cannot be grouped.
+
+    Pulling the far side into the region would move the submodule's computation with it,
+    so the instance is skipped -- loudly -- and the inner module is still delegated.
+    """
+    with pytest.warns(UserWarning, match="not contiguous"):
+        program = _convert(
+            OuterStraddle(), (IDX,), {"Straddle": "CPU", "Lookup": "Interpreter"}
+        )
+    ir = str(program)
+    assert ir.count('coreai.isolated_group<"Interpreter">') == 1
+    assert 'isolated_group<"CPU">' not in ir
+    _verify(program)
+
+
+def test_set_delegate_id_returns_self_for_chaining() -> None:
+    converter = TorchConverter()
+    assert converter._set_delegate_id("Lookup", "Interpreter") is converter
+
+
+def test_delegate_ids_persist_across_staged_programs() -> None:
+    """One converter, two entrypoints: both get the region."""
+    ep = torch.export.export(Net(), (X, IDX)).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    converter._set_delegate_id("Lookup", "Interpreter")
+    converter.add_exported_program(ep, entrypoint_name="first")
+    converter.add_exported_program(ep, entrypoint_name="second")
+    program = converter.to_coreai()
+    assert str(program).count('coreai.isolated_group<"Interpreter">') == 2
+    _verify(program)
+
+
+def test_region_is_isolated_from_above() -> None:
+    """Nothing inside may name an outer SSA value -- that is what makes it delegatable."""
+    ir = str(_convert(Net(), (X, IDX), {"Lookup": "Interpreter"}))
+    region = _region_of(ir, "Interpreter")
+    block_args = {
+        tok.strip().rstrip(":")
+        for tok in region.splitlines()[1].replace("(", " ").replace(")", " ").split()
+        if tok.startswith("%arg")
+    }
+    defined = {
+        ln.split("=")[0].strip() for ln in region.splitlines() if "=" in ln
+    } | block_args
+    for line in region.splitlines()[2:]:
+        if "=" not in line and "yield" not in line:
+            continue
+        rhs = line.split("=", 1)[-1]
+        for tok in rhs.replace(",", " ").replace("(", " ").replace(")", " ").split():
+            if tok.startswith("%"):
+                name = tok.split(":")[0]
+                assert name in defined, f"{name} escapes the region:\n{region}"
+
+
+@pytest.mark.asyncio
+async def test_delegation_preserves_numerics() -> None:
+    """A delegate is a placement hint: the result must be unchanged."""
+    model, args = LookupOnly(), (IDX,)
+    program = _convert(model, args, {"Lookup": "Interpreter"})
+    with TemporaryDirectory(suffix=".aimodel") as tmp:
+        asset = program.save_asset(Path(tmp))
+        async with asset.executable() as ai_model:
+            fn = ai_model.load_function("main")
+            out = await fn(inputs={"idx": NDArray(args[0].to(torch.int32))})
+            got = {k: v.numpy() for k, v in out.items()}
+            expected = {list(got)[0]: model(*args)}
+            assert compare_outputs(expected, got)
+
+
+# ---------------------------------------------------------------------------
+# _set_entrypoint_delegate_id: the whole procedure, not one module's ops
+# ---------------------------------------------------------------------------
+
+
+class ConstantOnly(nn.Module):
+    """A procedure whose body is a single constant, so nothing is attributed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("table", torch.arange(TABLE_ROWS, dtype=torch.uint8))
+
+    def forward(self) -> torch.Tensor:
+        return self.table
+
+
+def _convert_entrypoint_delegate(
+    model: nn.Module, args: tuple, target: str | None, entrypoint: str = "main"
+):
+    ep = torch.export.export(model, args).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    if target is not None:
+        converter._set_entrypoint_delegate_id(entrypoint, target)
+    converter.add_exported_program(ep, entrypoint_name=entrypoint)
+    return converter.to_coreai()
+
+
+def test_whole_procedure_is_wrapped_in_one_group() -> None:
+    """Every op in the body moves into the region, and the graph still verifies."""
+    program = _convert_entrypoint_delegate(Net(), (X, IDX), "Interpreter")
+    ir = str(program)
+
+    assert ir.count('coreai.isolated_group<"Interpreter">') == 1
+    region = _region_of(ir, "Interpreter")
+    # Ops from the delegated module and from its parent alike.
+    assert "coreai.gather_nd" in region
+    assert "reduce_sum" in region
+    # The terminator stays in the graph body; the region yields to it.
+    assert "coreai.output" not in region
+    assert "coreai.yield" in region
+    _verify(program)
+
+
+def test_constant_only_procedure_is_wrapped() -> None:
+    """The case attribution cannot express: no op belongs to any module.
+
+    ``_set_delegate_id`` has nothing to match here -- a constant is materialised during
+    graph setup, not attributed to a lowered node -- so it produces no region at all.
+    """
+    delegated = _convert_entrypoint_delegate(ConstantOnly(), (), "Interpreter")
+    assert 'coreai.isolated_group<"Interpreter">' in str(delegated)
+    _verify(delegated)
+
+    by_class = _convert(ConstantOnly(), (), {"ConstantOnly": "Interpreter"})
+    assert "isolated_group" not in str(by_class)
+
+
+def test_no_entrypoint_delegate_emits_no_region() -> None:
+    """Opt-in, and keyed by entrypoint name: another name leaves the graph untouched."""
+    assert "isolated_group" not in str(
+        _convert_entrypoint_delegate(Net(), (X, IDX), None)
+    )
+
+    program = _convert_entrypoint_delegate(
+        Net(), (X, IDX), "Interpreter", entrypoint="main"
+    )
+    assert "isolated_group" in str(program)
+
+    converter = TorchConverter()
+    converter._set_entrypoint_delegate_id("some_other_procedure", "Interpreter")
+    ep = torch.export.export(Net(), (X, IDX)).run_decompositions(get_decomp_table())
+    converter.add_exported_program(ep, entrypoint_name="main")
+    assert "isolated_group" not in str(converter.to_coreai())
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_delegate_preserves_numerics() -> None:
+    """Placement only: wrapping the whole procedure must not change the result."""
+    model, args = LookupOnly(), (IDX,)
+    program = _convert_entrypoint_delegate(model, args, "Interpreter")
+    with TemporaryDirectory(suffix=".aimodel") as tmp:
+        asset = program.save_asset(Path(tmp))
+        async with asset.executable() as ai_model:
+            fn = ai_model.load_function("main")
+            out = await fn(inputs={"idx": NDArray(args[0].to(torch.int32))})
+            got = {k: v.numpy() for k, v in out.items()}
+            expected = {list(got)[0]: model(*args)}
+            assert compare_outputs(expected, got)

--- a/tests/experimental/test_externalize_group.py
+++ b/tests/experimental/test_externalize_group.py
@@ -1,0 +1,561 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Grouping a module's converted ops, and shipping the result separately.
+
+``TorchConverter._set_externalize_group`` names a module class and outlines every op each
+instance contributed into its own ``coreai.graph``, marked ``externalize`` and reached by a
+``coreai.invoke``. Matching is by attribution -- what ``nn_module_stack`` says produced each
+op -- so it asks nothing of the module: no typed boundary, no schema, no particular call
+convention. ``Protocol`` below is the shape that forces the difference: its ``forward``
+dispatches on Python containers, so there is nothing a custom op could stand in for.
+
+The rest covers what happens to such graphs afterwards -- ``_externalize_graphs()`` splitting
+them into their own :class:`AIProgram`, the namespaces surviving a real asset round-trip, and
+the ``coreai`` pass underneath pinned directly.
+"""
+
+import re
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+from coreai.runtime import NDArray
+
+from coreai_torch import TorchConverter, get_decomp_table
+
+from ..utils import compare_outputs
+
+DIM = 4
+RANK = 2
+
+
+class Protocol(nn.Module):
+    """``forward`` takes a protocol, not tensors, and owns children that emit ops."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a_transpose = nn.Linear(DIM, RANK, bias=False)
+        self.b_transpose = nn.Linear(RANK, DIM, bias=False)
+        self.scale = 0.5
+
+    def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        x, base_out = kwargs["transformed_args"][0], kwargs["outputs"]
+        return base_out + self.b_transpose(self.a_transpose(x) * self.scale)
+
+
+class AdaptedLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.base = nn.Linear(DIM, DIM, bias=False)
+        self.branch = Protocol()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.branch(x, transformed_args=(x,), outputs=self.base(x))
+
+
+class Net(nn.Module):
+    def __init__(self, layers: int = 1) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(AdaptedLinear() for _ in range(layers))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x * 2.0
+
+
+class Scale(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.factor = 3.0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.factor
+
+
+class CalledTwice(nn.Module):
+    """One instance invoked twice, with the parent's own op in between.
+
+    A parent and its children are contiguous by construction, since attribution collects
+    the whole subtree -- so this is what a broken span actually looks like: two runs of
+    ops for the same instance with unrelated work between them.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shared = Scale()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.shared(self.shared(x) + 1.0)
+
+
+X = torch.randn(2, DIM)
+
+
+def _convert(
+    model: nn.Module,
+    groups: dict[str, Any],
+    *,
+    entrypoints: tuple[str, ...] = ("main",),
+    args: tuple = (X,),
+    name_map: dict[str, str] | None = None,
+    externalize: bool = True,
+):
+    """Export + convert with externalize groups set. Returns the AIProgram."""
+    ep = torch.export.export(model, args).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    for cls, namespace in groups.items():
+        converter._set_externalize_group(cls, namespace, externalize=externalize)
+    if name_map:
+        converter._set_externalize_name_map(name_map)
+    for entrypoint in entrypoints:
+        converter.add_exported_program(ep, entrypoint_name=entrypoint)
+    program = converter.to_coreai()
+    program._mlir_module.operation.verify()  # noqa: SLF001
+    return program
+
+
+def _outlined(program) -> list[str]:  # type: ignore[no-untyped-def]
+    """Headers of the outlined graphs (everything but the entrypoints)."""
+    return [
+        h
+        for h in re.findall(r"coreai\.graph[^\n]*", str(program))
+        if "noinline" in h or "externalize" in h
+    ]
+
+
+def _body_of(program, symbol: str) -> str:  # type: ignore[no-untyped-def]
+    """The text of the outlined graph named ``symbol``, up to its terminator."""
+    ir = str(program)
+    start = ir.index(f"@{symbol}(")
+    end = ir.index("coreai.output", start)
+    return ir[start:end]
+
+
+# --- the boundary attribution produces ---------------------------------------------
+
+
+def test_matched_module_is_outlined_into_its_own_graph() -> None:
+    program = _convert(Net(), {"Protocol": "lora.extend"})
+    assert len(_outlined(program)) == 1
+    assert "coreai.invoke @lora::@extend::@layers.0.branch" in str(program)
+
+
+def test_no_group_set_emits_no_outlined_graph() -> None:
+    """Opt-in: without the call, conversion is untouched."""
+    ir = str(_convert(Net(), {}))
+    assert "udml.namespace" not in ir
+    assert "coreai.invoke" not in ir
+
+
+def test_children_of_the_matched_module_come_with_it() -> None:
+    """The projections belong to their own ``Linear``, but to the side branch's graph.
+
+    Keying on the innermost module would leave the side branch only the ops it performed
+    *between* its children's, which is not a boundary at all.
+    """
+    program = _convert(Net(), {"Protocol": "lora.extend"})
+    body = _body_of(program, "layers.0.branch")
+    assert body.count("batch_matmul") == 2, body  # both projections
+    assert "broadcasting_add" in body  # and the residual add
+
+
+def test_base_layer_stays_outside() -> None:
+    program = _convert(Net(), {"Protocol": "lora.extend"})
+    body = _body_of(program, "layers.0.branch")
+    # three matmuls exist in total: base + two projections
+    assert str(program).count("batch_matmul") == 3
+    assert body.count("batch_matmul") == 2
+
+
+def test_arguments_are_unnamed() -> None:
+    """Attribution has no parameter names to draw on."""
+    header = _outlined(_convert(Net(), {"Protocol": "lora.extend"}))[0]
+    assert "coreai.name" not in header, header
+
+
+def test_boundary_is_the_values_that_cross_it() -> None:
+    """``(x, base_out) -> out``: two operands in, one result out."""
+    header = _outlined(_convert(Net(), {"Protocol": "lora.extend"}))[0]
+    assert header.count("%arg") == 2, header
+    invoke = re.search(
+        r"coreai\.invoke @lora::@extend::@\S+\(([^)]*)\)",
+        str(_convert(Net(), {"Protocol": "lora.extend"})),
+    )
+    assert invoke is not None and invoke.group(1).count(",") == 1
+
+
+def test_weights_are_pulled_into_the_outlined_graph() -> None:
+    """A constant used only inside travels with the ops rather than becoming an operand."""
+    model = Net()
+    with torch.no_grad():
+        model.layers[0].branch.a_transpose.weight.fill_(0.25)
+    program = _convert(model, {"Protocol": "lora.extend"})
+    assert "2.500000e-01" in _body_of(program, "layers.0.branch")
+
+
+# --- naming and placement ---------------------------------------------------------
+
+
+def test_graph_is_named_for_the_module_path() -> None:
+    program = _convert(Net(layers=2), {"Protocol": "lora.extend"})
+    symbols = {h.split("@")[1].split("(")[0] for h in _outlined(program)}
+    assert symbols == {"layers.0.branch", "layers.1.branch"}
+
+
+def test_one_graph_per_instance() -> None:
+    program = _convert(Net(layers=3), {"Protocol": "lora.extend"})
+    assert len(_outlined(program)) == 3
+
+
+def test_namespace_nesting_and_qualified_call() -> None:
+    ir = str(_convert(Net(), {"Protocol": "lora_32.extend"}))
+    assert "udml.namespace @lora_32" in ir
+    assert "namespace @extend" in ir
+    assert "coreai.invoke @lora_32::@extend::@" in ir
+
+
+def test_graph_is_marked_externalize() -> None:
+    assert "externalize" in _outlined(_convert(Net(), {"Protocol": "lora.extend"}))[0]
+
+
+def test_externalize_false_leaves_a_plain_noinline_graph() -> None:
+    header = _outlined(_convert(Net(), {"Protocol": "lora.extend"}, externalize=False))[
+        0
+    ]
+    assert "noinline" in header and "externalize" not in header
+
+
+def test_callable_namespace_is_given_the_entrypoint() -> None:
+    """One converter, several procedures, one namespace each.
+
+    Conversion is deferred to ``to_coreai``, so a plain string cannot be re-set between
+    ``add_exported_program`` calls -- the last value would win for every procedure.
+    """
+    program = _convert(
+        Net(),
+        {"Protocol": lambda ep: f"lora_32.{ep}"},
+        entrypoints=("extend", "prompt_opt"),
+    )
+    ir = str(program)
+    assert "coreai.invoke @lora_32::@extend::@" in ir
+    assert "coreai.invoke @lora_32::@prompt_opt::@" in ir
+
+
+def test_same_name_in_two_namespaces_does_not_collide() -> None:
+    """Every procedure has a side branch at the same module path; only the namespace differs."""
+    program = _convert(
+        Net(),
+        {"Protocol": lambda ep: f"lora_32.{ep}"},
+        entrypoints=("extend", "prompt_opt"),
+    )
+    assert len(_outlined(program)) == 2
+    # twice as a definition, twice as a qualified call -- the two definitions are
+    # distinguished by their namespace, not by their symbol
+    assert str(program).count("@layers.0.branch(") == 4
+    assert (
+        str(program).count("coreai.graph externalize noinline @layers.0.branch(") == 2
+    )
+
+
+def test_name_map_pins_the_emitted_symbol() -> None:
+    """For a tree restructured between procedures -- see ``_set_externalize_name_map``."""
+    program = _convert(
+        Net(),
+        {"Protocol": "lora.extend"},
+        name_map={"layers.0.branch": "pinned.path.branch"},
+    )
+    ir = str(program)
+    assert "@pinned.path.branch(" in ir
+    assert "coreai.invoke @lora::@extend::@pinned.path.branch" in ir
+
+
+def test_name_map_entries_that_match_nothing_are_ignored() -> None:
+    """One map can cover every procedure, including those needing no pinning."""
+    program = _convert(
+        Net(), {"Protocol": "lora.extend"}, name_map={"not.a.module": "x"}
+    )
+    assert "@layers.0.branch(" in str(program)
+
+
+# --- what cannot be grouped ------------------------------------------------------
+
+
+def test_unmatched_class_name_warns_rather_than_silently_doing_nothing() -> None:
+    """Matching goes through ``nn_module_stack``, so a no-match has to be loud.
+
+    A module invoked as ``module.forward(...)`` never enters the stack, so registering it
+    produces no graphs while conversion succeeds -- the missing side branchs would otherwise
+    surface only much later, if at all.
+    """
+    with pytest.warns(UserWarning, match="no ops were attributed"):
+        program = _convert(Net(), {"NoSuchModule": "lora.extend"})
+    assert _outlined(program) == []
+
+
+def test_matched_class_does_not_warn() -> None:
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        _convert(Net(), {"Protocol": "lora.extend"})
+
+
+def test_non_contiguous_module_is_skipped_with_warning() -> None:
+    """Ops in between belong to another module; outlining them would move its work."""
+    with pytest.warns(UserWarning, match="not contiguous"):
+        program = _convert(CalledTwice(), {"Scale": "g.main"})
+    assert _outlined(program) == []
+
+
+def test_set_externalize_group_returns_self_for_chaining() -> None:
+    converter = TorchConverter()
+    assert converter._set_externalize_group("Protocol", "lora.extend") is converter
+    assert converter._set_externalize_name_map({}) is converter
+
+
+# --- interaction with delegation --------------------------------------------------
+
+
+def test_outlining_composes_with_delegate_ids() -> None:
+    """Both groupings read op spans recorded during conversion.
+
+    The spans are *indices*, and each grouping rewrites the block -- so one must not
+    invalidate the other's. Delegating `Scale` and outlining the side branch exercises that.
+    """
+
+    class Mixed(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.layer = AdaptedLinear()
+            self.scale = Scale()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.scale(self.layer(x))
+
+    ep = torch.export.export(Mixed(), (X,)).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    converter._set_delegate_id("Scale", "Interpreter")
+    converter._set_externalize_group("Protocol", "lora.extend")
+    converter.add_exported_program(ep, entrypoint_name="main")
+    program = converter.to_coreai()
+    program._mlir_module.operation.verify()  # noqa: SLF001
+    ir = str(program)
+    assert 'coreai.isolated_group<"Interpreter">' in ir
+    assert "coreai.invoke @lora::@extend::@layer.branch" in ir
+    # the delegated region must hold Scale's op, not the side branch's
+    body = _body_of(program, "layer.branch")
+    assert "isolated_group" not in body
+
+
+# --- numerics --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outlining_preserves_numerics() -> None:
+    """Outlining is a structural move: the answer must be unchanged.
+
+    Run with ``externalize=False`` so the call resolves in one asset -- a graph marked
+    ``externalize`` is part of a separate module's public API by definition.
+    """
+    model = Net(layers=2)
+    expected = model(X).detach()
+    program = _convert(model, {"Protocol": "lora.extend"}, externalize=False)
+    with TemporaryDirectory(suffix=".aimodel") as tmp:
+        asset = program.save_asset(Path(tmp))
+        async with asset.executable() as ai_model:
+            out = await ai_model.load_function("main")(inputs={"x": NDArray(X)})
+            got = {k: v.numpy() for k, v in out.items()}
+            assert compare_outputs({list(got)[0]: expected}, got)
+
+
+class TwoTensorBranch(nn.Module):
+    """Combines a layer's input with its output -- a two-tensor boundary."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Conv2d(DIM, DIM, 1, bias=False)
+
+    def forward(self, x: torch.Tensor, base_out: torch.Tensor) -> torch.Tensor:
+        return base_out + self.proj(x)
+
+
+class LayerWithBranch(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.base = nn.Conv2d(DIM, DIM, 1, bias=False)
+        self.branch = TwoTensorBranch()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.branch(x, self.base(x)) * 2.0
+
+
+def _convert_branch(model: nn.Module, namespace: str = "group_a.stage_one"):
+    """Convert `model` with `SideBranch` outlined into `namespace`."""
+    args = (torch.randn(1, DIM, 1, DIM),)
+    ep = torch.export.export(model, args).run_decompositions(get_decomp_table())
+    converter = TorchConverter()
+    converter._set_externalize_group(TwoTensorBranch.__name__, namespace)
+    converter.add_exported_program(ep, entrypoint_name="main")
+    return converter.to_coreai()
+
+
+def test_externalize_graphs_splits_and_leaves_source_intact() -> None:
+    """Extraction must yield a marked-graphs-only program *without* consuming the source.
+
+    ``ISOLATE_EXTERNALIZED_GRAPHS`` mutates its module in place and ``AIProgram`` holds
+    ``_mlir_module`` by reference, so a naive call destroys the program you still need to
+    save. The helper clones first, so callers are order-independent and can inspect both
+    artifacts -- which a caller's graph extraction relies on.
+    """
+    from coreai_torch import _externalize_graphs
+
+    torch.manual_seed(42)
+    program = _convert_branch(LayerWithBranch().eval())
+    before = str(program)
+
+    extracted = _externalize_graphs(program)
+    extracted_ir, source_ir = str(extracted), str(program)
+
+    assert "@main" not in extracted_ir, (
+        f"extracted program should not contain the entrypoint:\n{extracted_ir[:400]}"
+    )
+    assert "coreai.conv2d" in extracted_ir, "extracted program lost the graph body"
+    assert source_ir == before, (
+        "extraction mutated the source program; it must clone (see docstring)"
+    )
+    # The op contract: survivors do not keep the attribute once externalized.
+    assert "coreai.graph externalize" not in extracted_ir, (
+        "externalize should be stripped from graphs in the extracted program"
+    )
+
+
+def test_nested_graphs_survive_asset_serialization() -> None:
+    """A namespaced program must serialize, not just verify in memory.
+
+    Two things this catches that an IR check cannot: a nested ``builtin.module`` (the
+    obvious choice for nesting) is unserializable, and an op created without an explicit
+    location inherits whatever is ambient, which can be a location the bytecode writer
+    cannot represent -- the module then verifies and prints fine but ``save_asset`` fails
+    with
+
+        Failed to serialize module to Bytecode: at #aicode.debuginfo.location_v1<
+            src = <file = <filename = "-", directory = "", sha256Sum = "">, ...
+
+    reported against the nested module op itself. So this test writes the asset and reads
+    it back.
+    """
+    torch.manual_seed(42)
+    program = _convert_branch(LayerWithBranch().eval())
+
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "nested.aimodel"
+        program.save_asset(path)
+        assert (path / "main.mlirb").is_file()
+
+        from coreai.authoring import AIProgram
+
+        reloaded = str(
+            AIProgram._load_bytecode(path / "main.mlirb")._mlir_module  # noqa: SLF001
+        )
+        assert "udml.namespace @group_a" in reloaded, "namespace lost in round-trip"
+        assert "namespace @stage_one" in reloaded, "inner namespace lost in round-trip"
+        assert "@group_a::@stage_one::@" in reloaded, "qualified callee lost"
+
+
+def test_isolate_pass_keeps_only_marked_graphs_and_strips_the_attribute() -> None:
+    """`ISOLATE_EXTERNALIZED_GRAPHS` semantics the feature relies on."""
+    import numpy as np
+    from coreai._compiler._transforms.passes import (
+        CorePasses,
+        GlobalOptions,
+        PassEntry,
+        apply_passes_sync,
+    )
+    from coreai._compiler.context import Context
+    from coreai._compiler.dialects import coreai as c
+    from coreai._compiler.ir import (
+        F16Type,
+        InsertionPoint,
+        Location,
+        Module,
+        RankedTensorType,
+    )
+    from coreai.authoring import AIProgram
+
+    ctx = Context()
+    with ctx._mlir_context, Location.unknown():  # noqa: SLF001
+        ty = RankedTensorType.get([1, 4], F16Type.get())
+        module = Module.create()
+
+        def graph(name: str, externalize: bool) -> None:
+            with InsertionPoint(module.body):
+                g = c.GraphOp(name, [ty], [ty], ["x"], ["y"], externalize=externalize)
+            block = g.regions[0].blocks[0]
+            with InsertionPoint(block):
+                one = c.constant(np.ones((1, 4), dtype=np.float16))
+                c.output([c.add(block.arguments[0], one)])
+
+        graph("base_entry", False)
+        graph("marked", True)
+
+        with TemporaryDirectory() as tmp:
+            apply_passes_sync(
+                module,
+                [PassEntry.get(CorePasses.ISOLATE_EXTERNALIZED_GRAPHS)],
+                GlobalOptions(output_directory=Path(tmp)),
+            )
+
+        names = [
+            op.attributes["sym_name"].value
+            for op in module.body.operations
+            if "sym_name" in op.attributes
+        ]
+        assert names == ["marked"], f"expected only the marked graph, got {names}"
+        assert "externalize" not in str(module), (
+            "the pass should strip `externalize` from graphs it keeps"
+        )
+        assert module.operation.verify()
+        # The pass is destructive: nothing of the source program survives.
+        assert AIProgram._from_mlir_module(module) is not None  # noqa: SLF001
+
+
+def test_externalize_attribute_is_settable_after_the_graph_is_built() -> None:
+    """`graph_op.externalize = True` works post-hoc, and the module still verifies.
+
+    This is what makes `_graph_externalize` cheap to implement: the converter can mark
+    the graph after `_get_graph_op` rather than threading the flag into construction.
+    """
+    import numpy as np
+    from coreai._compiler.context import Context
+    from coreai._compiler.dialects import coreai as c
+    from coreai._compiler.ir import (
+        F16Type,
+        InsertionPoint,
+        Location,
+        Module,
+        RankedTensorType,
+    )
+
+    ctx = Context()
+    with ctx._mlir_context, Location.unknown():  # noqa: SLF001
+        ty = RankedTensorType.get([1, 4], F16Type.get())
+        module = Module.create()
+        with InsertionPoint(module.body):
+            g = c.GraphOp("g", [ty], [ty], ["x"], ["y"])
+        block = g.regions[0].blocks[0]
+        with InsertionPoint(block):
+            one = c.constant(np.ones((1, 4), dtype=np.float16))
+            c.output([c.add(block.arguments[0], one)])
+
+        assert g.externalize is False
+        g.externalize = True
+        assert g.externalize is True
+        assert "coreai.graph externalize" in str(module)
+        assert module.operation.verify()

--- a/tests/ops/test_ops_ir.py
+++ b/tests/ops/test_ops_ir.py
@@ -12,7 +12,12 @@ from torch import Tensor
 
 import coreai_torch
 
-from ..utils import _all_dims_dynamic, filecheck_pattern, get_ir
+from ..utils import (
+    _all_dims_dynamic,
+    filecheck_pattern,
+    get_ir,
+    make_dynamic_shapes,
+)
 
 
 class TestUnaryOpsIR:
@@ -4605,6 +4610,40 @@ class TestIndexTensorIR:
                 // CHECK-NEXT:   }
                 // CHECK-NEXT: }
             """,
+        )
+
+    def test_two_indices_keep_statically_known_dims(self) -> None:
+        """Broadcasting index tensors must not drop dims torch already knows.
+
+        With two ``(1, S)`` index tensors and ``S`` dynamic, the common shape is built at
+        runtime, so result-type inference cannot see through it and drops *every* dim to
+        dynamic. Dim 0 is statically 1 on both indices, and losing it propagates through
+        the gather into the enclosing graph's signature.
+        """
+
+        class TwoIndexModel(nn.Module):
+            def forward(self, table: Tensor, i: Tensor, j: Tensor) -> Tensor:
+                return table[i, j]
+
+        ir = get_ir(
+            TwoIndexModel().eval(),
+            table=torch.rand(16, 16, 8),
+            i=torch.zeros(1, 4, dtype=torch.int64),
+            j=torch.zeros(1, 4, dtype=torch.int64),
+            # One shared Dim, so both indices carry the same dynamic length.
+            dynamic_shapes=make_dynamic_shapes(
+                table=[None, None, None], i=[None, "s"], j=[None, "s"]
+            ),
+        )
+        filecheck_pattern(
+            ir,
+            check_file="""
+                // CHECK: coreai.broadcast_to {{.*}} -> tensor<1x?xsi32>
+                // CHECK: coreai.gather_nd {{.*}} to tensor<1x?x8xf32>
+            """,
+        )
+        assert "tensor<?x?xsi32>" not in ir, (
+            "index broadcast dropped the statically known leading dim"
         )
 
 

--- a/tests/test_debug_locations.py
+++ b/tests/test_debug_locations.py
@@ -189,6 +189,26 @@ class DeepChainModel(nn.Module):
         return x
 
 
+class _Adapter(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.down = nn.Linear(8, 2, bias=False)
+        self.up = nn.Linear(2, 8, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.up(self.down(x))
+
+
+class _AdaptedBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(8, 8)
+        self.adapter = _Adapter()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x) + self.adapter(x)
+
+
 def _convert(model: nn.Module, depth_input: torch.Tensor) -> object:
     exported_program: ExportedProgram = torch.export.export(
         model.eval(), (depth_input,)
@@ -271,3 +291,33 @@ def test_output_maps_survive_deferred_operation_ids() -> None:
     asm = program._mlir_module.operation.get_asm(enable_debug_info=True)
 
     assert "output_maps" in asm, "no output maps were recorded"
+
+
+def test_externalized_operations_keep_their_debug_locations() -> None:
+    """Outlined operations still get IDs, even though outlining moves them.
+
+    IDs are assigned once the graph body is complete, which has to happen *before* the
+    grouping rewrites: an operation that has been outlined into its own graph is no longer
+    reachable from the graph it was converted into, and would never be given a location.
+    """
+    exported_program: ExportedProgram = torch.export.export(
+        _AdaptedBlock().eval(), (torch.randn(1, 8),)
+    )
+    exported_program = exported_program.run_decompositions(get_decomp_table())
+
+    converter: TorchConverter = TorchConverter()
+    converter._set_externalize_group("_Adapter", "adapters")
+    converter.add_exported_program(
+        exported_program, entrypoint_name="f", input_names=["x"], output_names=["y"]
+    )
+    program = converter.to_coreai()
+
+    module_operation = program._mlir_module.operation
+    assert "adapters" in str(module_operation), "expected the adapter to be outlined"
+
+    without_id = [
+        operation.name
+        for operation in _get_nested_operations(module_operation)
+        if get_operation_id(operation) is None
+    ]
+    assert not without_id, f"operations left without an ID: {sorted(set(without_id))}"

--- a/tests/test_externalize.py
+++ b/tests/test_externalize.py
@@ -4103,3 +4103,62 @@ async def test_externalize_multiple_staged_entries_numerics() -> None:
     await _validate_numerics(
         coreai_program, plain_model, plain_sample, function_name="plain"
     )
+
+
+def test_wrapper_delegating_getattr_is_not_mistaken_for_marked() -> None:
+    """A wrapper that forwards unknown attributes to its child must not be restored.
+
+    Giving each instance a distinct class by wrapping it is a common trick, and such a
+    wrapper typically delegates via ``__getattr__``. That makes the marked child's stamps
+    read back off the *wrapper* too, so a ``hasattr``-based search finds a module that was
+    never patched -- and then cannot unpatch it, because the attributes it found are not
+    its own (``AttributeError: ... has no attribute '_original_forward'``).
+    """
+
+    class Inner(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = nn.Linear(DIM, DIM, bias=False)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return cast(torch.Tensor, self.lin(x))
+
+    class Delegating(nn.Module):
+        def __init__(self, inner: nn.Module) -> None:
+            super().__init__()
+            self.add_module("wrapped", inner)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return cast(torch.Tensor, self.wrapped.forward(x))
+
+        def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
+            wrapped = self._modules.get("wrapped")
+            if wrapped is not None and hasattr(wrapped, name):
+                return getattr(wrapped, name)
+            return super().__getattr__(name)
+
+    class Net(nn.Module):
+        def __init__(self, inner: nn.Module) -> None:
+            super().__init__()
+            self.inner = Delegating(inner)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.inner(x) * 2.0
+
+    inner = Inner()
+    model = Net(inner)
+    _patch_model_for_externalization(model, [ExternalizeSpec(target_class=Inner)])
+    x = torch.randn(2, DIM)
+    ep = torch.export.export(model, (x,))
+    externalized = _subexport_and_restore(model, ep)
+    program = (
+        TorchConverter()
+        .add_exported_program(
+            ep.run_decompositions(get_decomp_table()),
+            entrypoint_name="main",
+            _externalized_exported_programs=externalized,
+        )
+        .to_coreai()
+    )
+    program._mlir_module.operation.verify()
+    assert not inner.__dict__.keys() & {"_original_forward", "_externalize_name"}


### PR DESCRIPTION
* Adds two experimental `TorchConverter` SPI hooks that act on **the ops a named `nn.Module` class
contributed**, identified by `nn_module_stack` attribution once the graph body is built:

| API | Effect |
|---|---|
| `_set_delegate_id(class_name, target)` | put all ops in the subgraph into a single `coreai.isolated_group<target>` graph |
| `_set_externalize_group(class_name, namespace, *, externalize=True)` | moves them into their own `coreai.graph` (marked `externalize`, inside `namespace`) and replaces them with a `coreai.invoke` |
| `_set_externalize_name_map(mapping)` | pins outlined graph symbols when the traced module path is not the name the artifact uses |

* Important to note that the SPIs are experimental and no guaranteed of not breaking in the future.
* I did try to integrate the feature with the existing `externalize` APIs - however, the solution become super tedious and need tons of model reauthorizing at the source torch model level - hence I decided to introduce this new approach 😄 Need more discussion to put this into production.
* Make debug info infra faster
